### PR TITLE
fix: canonical url was all pointing to homepage

### DIFF
--- a/src/components/Blog/Post/Post.tsx
+++ b/src/components/Blog/Post/Post.tsx
@@ -47,7 +47,6 @@ export default function Post({ meta, children, posts }: Props) {
         title={meta.title}
         description={meta.description}
         image={meta.image}
-        url={fullUrl}
         readingTime={meta.readingTime}
         publishDate={postDateTemplate.render(new Date(meta.date))}
       />

--- a/src/components/Seo/CommonMetaTags.tsx
+++ b/src/components/Seo/CommonMetaTags.tsx
@@ -24,7 +24,6 @@ export const CommonMetaTags = () => {
       <meta name="mobile-web-app-capable" content="yes" />
       {/* <meta ref={themeMetaRef} name="theme-color" content={colorMode === 'light' ? '#fff' : '#1A202C'} /> */}
       <meta ref={themeMetaRef} name="theme-color" content={'#1A202C'} />
-      <link rel="canonical" href={publicUrl} />
       <link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png" />
       <link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png" />
       <link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png" />

--- a/src/components/Seo/PageMetaTags.tsx
+++ b/src/components/Seo/PageMetaTags.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 export const publicUrl = 'https://jackyef.com';
 const defaultTitle = 'jackyef.com';
@@ -12,7 +13,6 @@ interface Props {
   image?: string;
   title?: string;
   description?: string;
-  url?: string;
   publishDate?: string;
   readingTime?: string;
 }
@@ -21,14 +21,17 @@ export const PageMetaTags: React.FC<Props> = ({
   image = defaultOgImage,
   title = defaultTitle,
   description = defaultDescription,
-  url = publicUrl,
   publishDate = '',
   readingTime = '',
 }) => {
+  const router = useRouter();
+  const url = `${publicUrl}${router.pathname}`;
+
   return (
     <Head>
       <title>{title}</title>
       <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
 
       {/* Facebook OG meta tags */}
       <meta property="og:url" content={url} />


### PR DESCRIPTION
Canonical URLs should point to the URL that can be considered to have a master copy of the current page. If all pages point to the homepage, google might just not crawl the page because it thought it is a duplicate page.

![image](https://user-images.githubusercontent.com/7252454/94821244-94b61d80-042b-11eb-9e1a-9bf27518e285.png)
