### PR TITLE
Add a CSS 3D depth system and apply it across the site

### DIFF
--- a/src/components/ErrorView/Error404View.tsx
+++ b/src/components/ErrorView/Error404View.tsx
@@ -2,6 +2,9 @@ import { useRef, useEffect, useState, useCallback } from 'react';
 import { motion, useMotionValue } from 'motion/react';
 import Link from 'next/link';
 
+import { ExtrudedText } from '@/components/three-d/ExtrudedText';
+import { Tilt3D } from '@/components/three-d/Tilt3D';
+
 import { cn } from '@/utils/styles/classNames';
 
 import { PageMetaTags } from '../Seo/PageMetaTags';
@@ -144,7 +147,13 @@ function BouncingDuck() {
   }, []);
 
   return (
-    <div ref={containerRef} className={cn("pointer-events-none absolute inset-0", !ready && "invisible")}>
+    <div
+      ref={containerRef}
+      className={cn(
+        'pointer-events-none absolute inset-0',
+        !ready && 'invisible',
+      )}
+    >
       <motion.div
         className="pointer-events-auto absolute cursor-pointer select-none"
         style={{ x, y, rotate, width: duckSize, height: duckSize }}
@@ -172,16 +181,21 @@ function BouncingDuck() {
 function DraggableDigit({
   children,
   delay = 0,
+  spin = 1,
 }: {
   children: React.ReactNode;
   delay?: number;
+  /** Direction the glyph swings on hover, so neighbours don't move in lockstep. */
+  spin?: 1 | -1;
 }) {
   return (
     <motion.span
-      className="inline-block cursor-grab select-none active:cursor-grabbing"
-      initial={{ y: -80, opacity: 0, scale: 0.5 }}
+      className="inline-block cursor-grab select-none active:cursor-grabbing preserve-3d"
+      // Drops in from well behind the page, then settles onto the plane.
+      initial={{ y: -80, z: -340, opacity: 0, scale: 0.5 }}
       animate={{
         y: 0,
+        z: 0,
         opacity: 1,
         scale: 1,
         transition: {
@@ -192,14 +206,14 @@ function DraggableDigit({
           delay,
         },
       }}
-      whileHover={{ scale: 1.1, rotate: Math.random() > 0.5 ? 5 : -5 }}
+      whileHover={{ z: 46, rotateY: 14 * spin }}
       whileTap={{ scale: 0.9 }}
       drag
       dragSnapToOrigin
       dragElastic={1}
       dragTransition={{ bounceStiffness: 300, bounceDamping: 15 }}
     >
-      {children}
+      <ExtrudedText>{children}</ExtrudedText>
     </motion.span>
   );
 }
@@ -215,8 +229,12 @@ export const Error404View = () => {
 
         {/* Content */}
         <div className="relative z-10 flex flex-col items-center text-center">
-          {/* Draggable 404 */}
-          <div
+          {/* Draggable 404 — extruded, and the whole block turns with the
+              pointer so you can look around the sides of the type */}
+          <Tilt3D
+            max={13}
+            perspective={1100}
+            lift={0}
             className={cn(
               'flex items-baseline gap-2 md:gap-4 mb-6',
               'font-[family-name:var(--font-fraunces)] font-bold',
@@ -224,10 +242,14 @@ export const Error404View = () => {
               'text-(--color-accent)',
             )}
           >
-            <DraggableDigit delay={0}>4</DraggableDigit>
+            <DraggableDigit delay={0} spin={-1}>
+              4
+            </DraggableDigit>
             <DraggableDigit delay={0.1}>0</DraggableDigit>
-            <DraggableDigit delay={0.2}>4</DraggableDigit>
-          </div>
+            <DraggableDigit delay={0.2} spin={-1}>
+              4
+            </DraggableDigit>
+          </Tilt3D>
 
           {/* Copy */}
           <motion.p

--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -1,4 +1,5 @@
 import { Surface } from '@/components/common/Surface';
+import { Tilt3D, Tilt3DSheen } from '@/components/three-d/Tilt3D';
 
 import { cn } from '@/utils/styles/classNames';
 
@@ -8,6 +9,18 @@ interface CardProps {
   hover?: boolean;
   padding?: 'none' | 'sm' | 'md';
   as?: React.ElementType;
+  /**
+   * Tilts the card in real 3D under the pointer and sweeps a specular
+   * highlight across it. Children wrapped in <Depth> pick up parallax as it
+   * moves. Automatically inert on touch devices and under Reduce Motion.
+   */
+  tilt?: boolean;
+  /**
+   * Applied to the tilt wrapper rather than the card surface. The wrapper
+   * becomes the grid/flex item, so layout placement belongs here.
+   * Ignored when `tilt` is off.
+   */
+  tiltClassName?: string;
 }
 
 const paddingMap = {
@@ -22,8 +35,10 @@ export function Card({
   hover,
   padding = 'none',
   as,
+  tilt,
+  tiltClassName,
 }: CardProps) {
-  return (
+  const surface = (
     <Surface
       as={as}
       rounded="xl"
@@ -31,10 +46,18 @@ export function Card({
         'card',
         hover && 'card-hover',
         paddingMap[padding],
+        // `relative` anchors the sheen, `preserve-3d` keeps <Depth> children in
+        // the tilt plane's 3D space, `h-full` fills the wrapper.
+        tilt && 'relative preserve-3d h-full',
         className,
       )}
     >
+      {tilt && <Tilt3DSheen />}
       {children}
     </Surface>
   );
+
+  if (!tilt) return surface;
+
+  return <Tilt3D className={tiltClassName}>{surface}</Tilt3D>;
 }

--- a/src/components/home/BlueprintSolid.tsx
+++ b/src/components/home/BlueprintSolid.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useRef } from 'react';
+import { motion, useMotionValue, useSpring } from 'motion/react';
+
+import { Cube3D } from '@/components/three-d/Cube3D';
+
+import { useFinePointer } from '@/hooks/useFinePointer';
+import { useReduceMotion } from '@/hooks/useReduceMotion';
+
+import { cn } from '@/utils/styles/classNames';
+
+/* ─────────────────────────────────────────────────────────────
+   BlueprintSolid — the hero's drafted volume.
+
+   A translucent CSS-3D cube with grid-ruled faces, orbited by two
+   dashed guide rings. It idles on its own and turns to follow the
+   pointer anywhere on the page, so it reads as an object sitting
+   on the blueprint rather than a decal printed on it.
+   ───────────────────────────────────────────────────────────── */
+
+const SIZE = 220;
+const CUBE = 112;
+const RING_OUTER = 188;
+const RING_INNER = 142;
+
+/**
+ * Resting pitch. Negative tips the near edge toward the viewer, which is what
+ * puts the top face in view.
+ */
+const BASE_PITCH = -14;
+const MAX_YAW = 20;
+const MAX_PITCH = 13;
+/** Distance from the solid's centre over which the pointer still steers it. */
+const INFLUENCE = 560;
+
+const SPRING = { stiffness: 90, damping: 20, mass: 0.9 };
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const CORNER_POSITIONS = [
+  'left-0 top-0 -translate-x-1/2 -translate-y-1/2',
+  'right-0 top-0 translate-x-1/2 -translate-y-1/2',
+  'left-0 bottom-0 -translate-x-1/2 translate-y-1/2',
+  'right-0 bottom-0 translate-x-1/2 translate-y-1/2',
+];
+
+/**
+ * Drafting marks on a face: vertex squares plus a centre target.
+ * Deliberately symmetric, so faces read the same from either side of the
+ * translucent solid as it turns.
+ */
+function FaceMarks() {
+  return (
+    <>
+      {CORNER_POSITIONS.map((position) => (
+        <span
+          key={position}
+          className={cn('absolute w-[5px] h-[5px]', position)}
+          style={{ background: 'var(--solid-edge)' }}
+        />
+      ))}
+
+      <span
+        className="absolute left-1/2 top-1/2 w-[18px] h-px -translate-x-1/2 -translate-y-1/2"
+        style={{ background: 'var(--solid-edge)' }}
+      />
+      <span
+        className="absolute left-1/2 top-1/2 w-px h-[18px] -translate-x-1/2 -translate-y-1/2"
+        style={{ background: 'var(--solid-edge)' }}
+      />
+      <span
+        className="absolute left-1/2 top-1/2 w-[15px] h-[15px] -translate-x-1/2 -translate-y-1/2 rounded-full border"
+        style={{ borderColor: 'var(--solid-edge)' }}
+      />
+    </>
+  );
+}
+
+export function BlueprintSolid({ className }: { className?: string }) {
+  const reduceMotion = useReduceMotion();
+  const finePointer = useFinePointer();
+  const steerable = finePointer && !reduceMotion;
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  const yawTarget = useMotionValue(0);
+  const pitchTarget = useMotionValue(BASE_PITCH);
+  const yaw = useSpring(yawTarget, SPRING);
+  const pitch = useSpring(pitchTarget, SPRING);
+
+  useEffect(() => {
+    if (!steerable) {
+      yawTarget.set(0);
+      pitchTarget.set(BASE_PITCH);
+      return;
+    }
+
+    let frame = 0;
+    const pointer = { x: 0, y: 0 };
+
+    const apply = () => {
+      frame = 0;
+
+      const el = ref.current;
+      if (!el) return;
+
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0) return;
+
+      const dx = clamp(
+        (pointer.x - (rect.left + rect.width / 2)) / INFLUENCE,
+        -1,
+        1,
+      );
+      const dy = clamp(
+        (pointer.y - (rect.top + rect.height / 2)) / INFLUENCE,
+        -1,
+        1,
+      );
+
+      // Turn toward the cursor: the far side swings back, and the solid looks
+      // down when the pointer drops below it.
+      yawTarget.set(dx * MAX_YAW);
+      pitchTarget.set(BASE_PITCH - dy * MAX_PITCH);
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      pointer.x = event.clientX;
+      pointer.y = event.clientY;
+
+      if (frame) return;
+      frame = requestAnimationFrame(apply);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove, {
+      passive: true,
+    });
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, [steerable, yawTarget, pitchTarget]);
+
+  const animation = (value: string) =>
+    reduceMotion ? undefined : { animation: value };
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={cn('relative select-none', className)}
+      style={{ width: SIZE, height: SIZE }}
+    >
+      {/* Contact shadow — kept outside the 3D chain because `filter` would
+          flatten it out of the scene. */}
+      <div
+        className="solid-shadow absolute left-1/2 bottom-[10px] -translate-x-1/2 w-[124px] h-[16px] rounded-[50%]"
+        style={animation('solid-shadow-breathe 7s ease-in-out infinite')}
+      />
+
+      {/* Pointer parallax */}
+      <motion.div
+        className="preserve-3d absolute inset-0"
+        style={{ transformPerspective: 620, rotateX: pitch, rotateY: yaw }}
+      >
+        {/* Idle float */}
+        <div
+          className="preserve-3d absolute inset-0"
+          style={animation('solid-bob 7s ease-in-out infinite')}
+        >
+          {/* Outer guide ring */}
+          <div
+            className="preserve-3d absolute inset-0 grid place-items-center"
+            style={animation('solid-spin 34s linear infinite')}
+          >
+            <div
+              className="solid-ring"
+              style={{
+                width: RING_OUTER,
+                height: RING_OUTER,
+                transform: 'rotateX(70deg)',
+              }}
+            />
+          </div>
+
+          {/* Inner guide ring, counter-rotating */}
+          <div
+            className="preserve-3d absolute inset-0 grid place-items-center"
+            style={animation('solid-spin 21s linear infinite reverse')}
+          >
+            <div
+              className="solid-ring"
+              style={{
+                width: RING_INNER,
+                height: RING_INNER,
+                transform: 'rotateX(66deg) rotateY(24deg)',
+              }}
+            />
+          </div>
+
+          {/* The solid */}
+          <div
+            className="preserve-3d absolute inset-0 grid place-items-center"
+            style={animation('solid-spin 26s linear infinite')}
+          >
+            <Cube3D
+              size={CUBE}
+              faceClassName="solid-face"
+              faceClassNames={{
+                front: 'solid-face-front',
+                back: 'solid-face-front',
+              }}
+              faces={{
+                front: <FaceMarks />,
+                back: <FaceMarks />,
+                right: <FaceMarks />,
+                left: <FaceMarks />,
+              }}
+            />
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -1,43 +1,49 @@
 import { Heading } from '@/components/common/Heading';
 
+import { BlueprintSolid } from './BlueprintSolid';
 import { HeroCTA } from './HeroCTA';
 
 export function HeroSection() {
   return (
-    <div className="hero-pad">
-      {/* Heading */}
-      <Heading level="hero" className="mt-6 mb-3">
-        Jacky <em>Efendi</em>
-      </Heading>
+    <div className="hero-pad flex items-start gap-8">
+      <div className="min-w-0 flex-1">
+        {/* Heading */}
+        <Heading level="hero" className="mt-6 mb-3">
+          Jacky <em>Efendi</em>
+        </Heading>
 
-      {/* Role */}
-      <p
-        className="font-serif font-light text-(--color-ink-2) mb-[18px] tracking-[-0.01em]"
-        style={{ fontSize: 'clamp(18px, 2.5vw, 24px)' }}
-      >
-        Product Engineer, Frontend &amp; beyond.
-      </p>
+        {/* Role */}
+        <p
+          className="font-serif font-light text-(--color-ink-2) mb-[18px] tracking-[-0.01em]"
+          style={{ fontSize: 'clamp(18px, 2.5vw, 24px)' }}
+        >
+          Product Engineer, Frontend &amp; beyond.
+        </p>
 
-      {/* Description */}
-      <p className="text-[15px] leading-[1.75] text-(--color-ink-3) mb-4 max-w-[540px]">
-        I build for the web: performance, design systems, developer
-        tooling, and the product interfaces people actually use. Frontend is
-        where I go deepest, but I&apos;ve spent enough time in the surrounding
-        infrastructure to understand how the whole thing fits together.
-      </p>
+        {/* Description */}
+        <p className="text-[15px] leading-[1.75] text-(--color-ink-3) mb-4 max-w-[540px]">
+          I build for the web: performance, design systems, developer tooling,
+          and the product interfaces people actually use. Frontend is where I go
+          deepest, but I&apos;ve spent enough time in the surrounding
+          infrastructure to understand how the whole thing fits together.
+        </p>
 
-      <p className="text-[15px] leading-[1.75] text-(--color-ink-3) mb-8 max-w-[540px]">
-        8 years in, 5 fully remote across teams on 5 continents.
-        I&apos;ve come to believe async work runs on a few things: writings that
-        leave little room for guessing, questions asked early but not treated as
-        blockers, a bias toward making progress with what you have and trust
-        that everyone is doing the same.
-      </p>
+        <p className="text-[15px] leading-[1.75] text-(--color-ink-3) mb-8 max-w-[540px]">
+          8 years in, 5 fully remote across teams on 5 continents. I&apos;ve
+          come to believe async work runs on a few things: writings that leave
+          little room for guessing, questions asked early but not treated as
+          blockers, a bias toward making progress with what you have and trust
+          that everyone is doing the same.
+        </p>
 
-      {/* CTAs */}
-      <div className="flex gap-2.5 flex-wrap">
-        <HeroCTA />
+        {/* CTAs */}
+        <div className="flex gap-2.5 flex-wrap">
+          <HeroCTA />
+        </div>
       </div>
+
+      {/* Decorative 3D solid — only where there is room for it to breathe */}
+      <BlueprintSolid className="hidden lg:block shrink-0 mt-8" />
     </div>
   );
 }

--- a/src/components/home/WidgetGrid.tsx
+++ b/src/components/home/WidgetGrid.tsx
@@ -14,9 +14,16 @@ import {
 import { StatusDot } from '@/components/common/StatusDot';
 import { TypewriterText } from '@/components/common/TypewriterText';
 import { IOWrapper } from '@/components/IntersectionObserver/Wrapper';
-
+import { Depth } from '@/components/three-d/Tilt3D';
 import { SOCIALS } from '@/constants/socials';
+
 import { cn } from '@/utils/styles/classNames';
+
+/**
+ * Height each widget's content floats above its card face. Accents nest a
+ * second <Depth> inside this one, so their offsets compose on top of it.
+ */
+const CONTENT_DEPTH = 16;
 
 interface WidgetProps {
   label: string;
@@ -33,9 +40,16 @@ function Widget({ label, children, span = 1, mobileFullWidth }: WidgetProps) {
   );
 
   return (
-    <Card hover className={cn('px-[16px] py-[14px] cursor-default', gridClass)}>
-      <SectionLabel className="mb-2">{label}</SectionLabel>
-      {children}
+    <Card
+      tilt
+      hover
+      tiltClassName={gridClass}
+      className="px-[16px] py-[14px] cursor-default"
+    >
+      <Depth z={CONTENT_DEPTH}>
+        <SectionLabel className="mb-2">{label}</SectionLabel>
+        {children}
+      </Depth>
     </Card>
   );
 }
@@ -92,11 +106,13 @@ function NowWidget() {
 
 function ChessWidgetSkeleton() {
   return (
-    <Card hover className="px-[16px] py-[14px] cursor-default">
-      <SectionLabel className="mb-2">Chess.com</SectionLabel>
-      <div className="min-h-[180px] flex items-center justify-center">
-        <span className="text-[13px] text-(--color-ink-4)">Loading…</span>
-      </div>
+    <Card tilt hover className="px-[16px] py-[14px] cursor-default">
+      <Depth z={CONTENT_DEPTH}>
+        <SectionLabel className="mb-2">Chess.com</SectionLabel>
+        <div className="min-h-[180px] flex items-center justify-center">
+          <span className="text-[13px] text-(--color-ink-4)">Loading…</span>
+        </div>
+      </Depth>
     </Card>
   );
 }
@@ -108,43 +124,51 @@ export type BlogStats = {
 function AboutWidget({ blogStats }: { blogStats: BlogStats }) {
   return (
     <Card
+      tilt
       hover
-      className="px-[16px] py-[14px] cursor-default widget-mobile-full md:row-span-2 self-start"
+      tiltClassName="widget-mobile-full md:row-span-2 self-start"
+      className="px-[16px] py-[14px] cursor-default"
     >
-      <SectionLabel className="mb-3">Writing</SectionLabel>
-      <div className="font-serif text-[56px] font-bold text-(--color-ink) leading-none">
-        {blogStats.postCount}
-      </div>
-      <div className="text-[13px] text-(--color-ink-3) mt-1">
-        writings total
-      </div>
-      <a
-        href="/blog"
-        className="inline-block mt-2 text-[13px] text-(--color-accent-text) no-underline hover:underline"
-      >
-        Read the blog →
-      </a>
+      <Depth z={CONTENT_DEPTH}>
+        <SectionLabel className="mb-3">Writing</SectionLabel>
+        {/* The count is the loudest thing on this card, so it sits highest */}
+        <Depth
+          z={14}
+          className="font-serif text-[56px] font-bold text-(--color-ink) leading-none"
+        >
+          {blogStats.postCount}
+        </Depth>
+        <div className="text-[13px] text-(--color-ink-3) mt-1">
+          writings total
+        </div>
+        <a
+          href="/blog"
+          className="inline-block mt-2 text-[13px] text-(--color-accent-text) no-underline hover:underline"
+        >
+          Read the blog →
+        </a>
 
-      <hr className="border-(--color-border) my-4" />
+        <hr className="border-(--color-border) my-4" />
 
-      <SectionLabel className="mb-2.5">Connect</SectionLabel>
-      <ul className="space-y-2.5">
-        {SOCIALS.map(({ href, label, icon }) => (
-          <li key={href}>
-            <a
-              href={href}
-              target={'_blank'}
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 text-[14px] text-(--color-ink-2) hover:text-(--color-accent-text) transition-colors"
-            >
-              <span className="text-(--color-ink-4) transform -translate-y-0.5">
-                {icon}
-              </span>
-              <span>{label}</span>
-            </a>
-          </li>
-        ))}
-      </ul>
+        <SectionLabel className="mb-2.5">Connect</SectionLabel>
+        <ul className="space-y-2.5">
+          {SOCIALS.map(({ href, label, icon }) => (
+            <li key={href}>
+              <a
+                href={href}
+                target={'_blank'}
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 text-[14px] text-(--color-ink-2) hover:text-(--color-accent-text) transition-colors"
+              >
+                <span className="text-(--color-ink-4) transform -translate-y-0.5">
+                  {icon}
+                </span>
+                <span>{label}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </Depth>
     </Card>
   );
 }
@@ -264,13 +288,15 @@ function ChessWidget() {
   return (
     <Widget label="Chess.com">
       <div className="relative min-h-[180px]">
-        {/* Decorative chess board pattern */}
-        <div
+        {/* Decorative chess board pattern — set back behind the content so it
+            reads as printed on the card face */}
+        <Depth
+          z={-CONTENT_DEPTH}
           className="absolute top-[-4px] right-0 opacity-[0.05] pointer-events-none"
           aria-hidden="true"
         >
           <ChessBoardDeco />
-        </div>
+        </Depth>
 
         {/* Time control picker */}
         <SegmentedControl
@@ -282,14 +308,15 @@ function ChessWidget() {
 
         {/* Rating hero */}
         <div className="mt-4">
-          <div
+          <Depth
+            z={14}
             className={cn(
               'font-serif text-[42px] font-bold text-(--color-ink) leading-none transition-opacity duration-300',
               stats ? 'opacity-100' : 'opacity-30',
             )}
           >
             <AnimatedNumber value={stats?.rating_last} />
-          </div>
+          </Depth>
           <div className="text-[13px] text-(--color-ink-3) mt-1">
             {stats ? `Peak ${stats.rating_max}` : '\u00A0'}
           </div>
@@ -354,7 +381,9 @@ export function WidgetGrid({ blogStats }: { blogStats: BlogStats }) {
 
       <Widget label="Based in" mobileFullWidth>
         <div className="flex items-center gap-2.5 mt-1">
-          <span className="text-[28px]">🇮🇩</span>
+          <Depth z={12} className="text-[28px]">
+            🇮🇩
+          </Depth>
           <div>
             <WidgetValue>
               <span className="text-[17px]">Jakarta</span>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -89,14 +89,23 @@ export function MobileNav() {
         {open && (
           <motion.div
             key="mobile-nav-card"
-            initial={{ opacity: 0, scale: 0.9, rotate: -3, y: 16 }}
-            animate={{ opacity: 1, scale: 1, rotate: 0, y: 0 }}
-            exit={{ opacity: 0, scale: 0.9, rotate: -3, y: 16 }}
+            // Hinges up off the FAB rather than just scaling in: the panel
+            // starts lying flat against the page and swings upright.
+            initial={{
+              opacity: 0,
+              scale: 0.94,
+              rotate: -2,
+              rotateX: -52,
+              y: 20,
+            }}
+            animate={{ opacity: 1, scale: 1, rotate: 0, rotateX: 0, y: 0 }}
+            exit={{ opacity: 0, scale: 0.94, rotate: -2, rotateX: -52, y: 20 }}
             transition={{ type: 'spring', stiffness: 400, damping: 28 }}
             className="fixed right-5 z-49 min-w-50"
             style={{
               bottom: 'calc(88px + env(safe-area-inset-bottom, 0px))',
               transformOrigin: 'bottom right',
+              transformPerspective: 1000,
             }}
           >
             <Surface elevation="lg" rounded="xl" className="overflow-hidden">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { Search } from 'lucide-react';
 
 import { useCommandPaletteContext } from '@/components/CommandPalette/hooks/useCommandPaletteContext';
+import { Cube3D } from '@/components/three-d/Cube3D';
 
 import { useTheme } from '@/hooks/useTheme';
 
@@ -8,13 +9,34 @@ import { PwaInstallButton } from './PwaInstallButton';
 import { SidebarNav } from './SidebarNav';
 import { ThemeSwitcher } from './ThemeSwitcher';
 
+const LOGO_SIZE = 26;
+
 function LogoMark() {
   return (
-    <div className="flex items-center gap-[9px]">
-      <div className="w-[26px] h-[26px] rounded-[7px] bg-(--color-accent) flex items-center justify-center shrink-0">
-        <span className="text-white text-[13px] font-bold font-serif leading-none">
-          J
-        </span>
+    <div className="group flex items-center gap-[9px]">
+      {/* Monogram as a real solid — resting slightly turned so the depth
+          reads, and rolling onto its next face on hover. */}
+      <div
+        className="shrink-0 logo-scene"
+        style={{ width: LOGO_SIZE, height: LOGO_SIZE }}
+      >
+        <Cube3D
+          size={LOGO_SIZE}
+          className="logo-cube"
+          faceClassName="rounded-[6px] bg-(--color-accent) text-white text-[13px] font-bold font-serif leading-none"
+          // Side and top faces sit in shade. Without that falloff a solid this
+          // small just reads as a flat tile with a rendering seam.
+          faceClassNames={{
+            right: 'logo-face-side',
+            left: 'logo-face-side',
+            top: 'logo-face-top',
+            bottom: 'logo-face-top',
+          }}
+          faces={{
+            front: <span className="logo-glyph logo-glyph-front">J</span>,
+            right: <span className="logo-glyph logo-glyph-side">E</span>,
+          }}
+        />
       </div>
       {/* Hide domain text on narrow (icon-strip) sidebar */}
       <span className="hidden lg:inline font-serif text-[15px] font-semibold text-(--color-ink) tracking-[-0.01em]">
@@ -29,7 +51,10 @@ export function Sidebar() {
   const { theme, setTheme } = useTheme();
 
   return (
-    <aside aria-label="Main navigation" className="sidebar shrink-0 h-dvh sticky top-0 flex flex-col bg-(--color-bg-sidebar) border-r border-(--color-border) overflow-y-auto overflow-x-hidden md:w-[60px] lg:w-[220px]">
+    <aside
+      aria-label="Main navigation"
+      className="sidebar shrink-0 h-dvh sticky top-0 flex flex-col bg-(--color-bg-sidebar) border-r border-(--color-border) overflow-y-auto overflow-x-hidden md:w-[60px] lg:w-[220px]"
+    >
       {/* Top: Logo + CMD trigger */}
       <div className="px-4 pt-[18px] pb-3 border-b border-(--color-border)">
         <LogoMark />

--- a/src/components/three-d/Cube3D.tsx
+++ b/src/components/three-d/Cube3D.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import { cn } from '@/utils/styles/classNames';
+
+/* ─────────────────────────────────────────────────────────────
+   Cube3D — six real faces on a preserve-3d plane.
+
+   Each face is pushed out half the cube's size along its own
+   normal, so the solid stays centred on its parent's origin and
+   can be rotated freely by whatever wraps it.
+   ───────────────────────────────────────────────────────────── */
+
+export type CubeFace = 'front' | 'back' | 'right' | 'left' | 'top' | 'bottom';
+
+const FACE_ORDER: CubeFace[] = [
+  'front',
+  'back',
+  'right',
+  'left',
+  'top',
+  'bottom',
+];
+
+const FACE_ROTATION: Record<CubeFace, string> = {
+  front: 'rotateY(0deg)',
+  back: 'rotateY(180deg)',
+  right: 'rotateY(90deg)',
+  left: 'rotateY(-90deg)',
+  top: 'rotateX(90deg)',
+  bottom: 'rotateX(-90deg)',
+};
+
+export interface Cube3DProps {
+  /** Edge length in px. */
+  size: number;
+  className?: string;
+  /** Applied to every face. */
+  faceClassName?: string;
+  /** Per-face overrides, merged after `faceClassName`. */
+  faceClassNames?: Partial<Record<CubeFace, string>>;
+  /** Content rendered inside a given face. */
+  faces?: Partial<Record<CubeFace, React.ReactNode>>;
+  style?: React.CSSProperties;
+}
+
+export function Cube3D({
+  size,
+  className,
+  faceClassName,
+  faceClassNames,
+  faces,
+  style,
+}: Cube3DProps) {
+  const half = size / 2;
+
+  return (
+    <div
+      className={cn('preserve-3d relative', className)}
+      style={{ width: size, height: size, ...style }}
+    >
+      {FACE_ORDER.map((face) => (
+        <div
+          key={face}
+          className={cn(
+            'absolute inset-0 flex items-center justify-center',
+            faceClassName,
+            faceClassNames?.[face],
+          )}
+          style={{
+            transform: `${FACE_ROTATION[face]} translateZ(${half}px)`,
+          }}
+        >
+          {faces?.[face]}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/three-d/ExtrudedText.tsx
+++ b/src/components/three-d/ExtrudedText.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { useTilt3DContext } from '@/components/three-d/Tilt3D';
+
+import { cn } from '@/utils/styles/classNames';
+
+/* ─────────────────────────────────────────────────────────────
+   ExtrudedText — gives glyphs a solid body.
+
+   Stacks copies of the same content at descending translateZ so
+   the type reads as a machined block rather than flat fill. Needs
+   a perspective ancestor (a <Tilt3D>, typically) to be visible;
+   without one it collapses back to plain text at zero cost.
+   ───────────────────────────────────────────────────────────── */
+
+export interface ExtrudedTextProps {
+  children: React.ReactNode;
+  /** Total depth of the body, in px. */
+  depth?: number;
+  /**
+   * Copies used to fake the body. Steps need to stay under ~2px or the
+   * stack separates into visible bands when viewed off-axis.
+   */
+  layers?: number;
+  /** Colour of the extruded sides. */
+  sideColor?: string;
+  className?: string;
+}
+
+export function ExtrudedText({
+  children,
+  depth = 30,
+  layers = 16,
+  sideColor = 'var(--extrude-side)',
+  className,
+}: ExtrudedTextProps) {
+  const tilt = useTilt3DContext();
+
+  // Inside a Tilt3D that has opted out (touch, reduced motion) there is no
+  // perspective to render into, so skip the stack entirely.
+  const flattened = tilt !== null && !tilt.enabled;
+  const step = depth / layers;
+
+  return (
+    <span className={cn('preserve-3d relative inline-block', className)}>
+      {!flattened &&
+        Array.from({ length: layers }, (_, index) => (
+          <span
+            key={index}
+            aria-hidden="true"
+            className="absolute inset-0 whitespace-pre"
+            style={{
+              color: sideColor,
+              transform: `translateZ(${-(index + 1) * step}px)`,
+            }}
+          >
+            {children}
+          </span>
+        ))}
+
+      <span className="relative">{children}</span>
+    </span>
+  );
+}

--- a/src/components/three-d/Tilt3D.tsx
+++ b/src/components/three-d/Tilt3D.tsx
@@ -1,0 +1,268 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  motion,
+  useMotionTemplate,
+  useMotionValue,
+  useSpring,
+  useTransform,
+  type MotionValue,
+  type SpringOptions,
+} from 'motion/react';
+
+import { useFinePointer } from '@/hooks/useFinePointer';
+import { useReduceMotion } from '@/hooks/useReduceMotion';
+
+import { cn } from '@/utils/styles/classNames';
+
+/* ─────────────────────────────────────────────────────────────
+   Tilt3D — a surface that rotates in real 3D under the pointer.
+
+   The rotated element is a single node, so it can be a grid/flex
+   item directly: perspective is baked into its own transform via
+   `transformPerspective` rather than requiring a wrapper.
+
+   Everything inside sits on a `preserve-3d` plane, so <Depth> can
+   push content toward the viewer and pick up genuine parallax.
+   ───────────────────────────────────────────────────────────── */
+
+type Tilt3DContextValue = {
+  /** Pointer position over the surface, normalised 0–1 on each axis. */
+  pointerX: MotionValue<number>;
+  pointerY: MotionValue<number>;
+  /** Springs 0 → 1 while the pointer is over the surface. */
+  hover: MotionValue<number>;
+  /** False when 3D is suppressed (touch input or reduced motion). */
+  enabled: boolean;
+};
+
+const Tilt3DContext = createContext<Tilt3DContextValue | null>(null);
+
+/** Motion values for the nearest enclosing <Tilt3D>, or null outside one. */
+export function useTilt3DContext() {
+  return useContext(Tilt3DContext);
+}
+
+const TILT_SPRING: SpringOptions = { stiffness: 210, damping: 24, mass: 0.7 };
+const HOVER_SPRING: SpringOptions = { stiffness: 220, damping: 30 };
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+export interface Tilt3DProps {
+  children: React.ReactNode;
+  className?: string;
+  /** Peak rotation on each axis, in degrees. */
+  max?: number;
+  /** Viewing distance in px — smaller exaggerates the perspective. */
+  perspective?: number;
+  /** How far the surface rises toward the viewer on hover, in px. */
+  lift?: number;
+}
+
+export function Tilt3D({
+  children,
+  className,
+  max = 6,
+  perspective = 1200,
+  lift = 14,
+}: Tilt3DProps) {
+  const reduceMotion = useReduceMotion();
+  const finePointer = useFinePointer();
+  const enabled = finePointer && !reduceMotion;
+
+  const ref = useRef<HTMLDivElement>(null);
+  const frameRef = useRef(0);
+  const pointerRef = useRef({ x: 0, y: 0 });
+  const [active, setActive] = useState(false);
+
+  const pointerX = useMotionValue(0.5);
+  const pointerY = useMotionValue(0.5);
+
+  const hoverTarget = useMotionValue(0);
+  const hover = useSpring(hoverTarget, HOVER_SPRING);
+
+  const rotateXTarget = useMotionValue(0);
+  const rotateYTarget = useMotionValue(0);
+  const rotateX = useSpring(rotateXTarget, TILT_SPRING);
+  const rotateY = useSpring(rotateYTarget, TILT_SPRING);
+  const z = useTransform(hover, (value) => value * lift);
+
+  /* Layout is read once per frame inside rAF rather than on every pointermove,
+     so a fast drag across a grid of cards can't thrash style recalculation. */
+  const readPointer = useCallback(() => {
+    frameRef.current = 0;
+
+    const el = ref.current;
+    if (!el) return;
+
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+
+    const nx = clamp01((pointerRef.current.x - rect.left) / rect.width);
+    const ny = clamp01((pointerRef.current.y - rect.top) / rect.height);
+
+    pointerX.set(nx);
+    pointerY.set(ny);
+
+    // Positive rotateY pushes the right edge away, positive rotateX pushes the
+    // top edge away — together they read as the surface dipping under the
+    // cursor, like pressing a card into the page.
+    rotateYTarget.set((nx - 0.5) * 2 * max);
+    rotateXTarget.set((0.5 - ny) * 2 * max);
+  }, [max, pointerX, pointerY, rotateXTarget, rotateYTarget]);
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      pointerRef.current.x = event.clientX;
+      pointerRef.current.y = event.clientY;
+
+      if (frameRef.current) return;
+      frameRef.current = requestAnimationFrame(readPointer);
+    },
+    [readPointer],
+  );
+
+  const handlePointerEnter = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      handlePointerMove(event);
+      hoverTarget.set(1);
+      setActive(true);
+    },
+    [handlePointerMove, hoverTarget],
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    if (frameRef.current) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = 0;
+    }
+
+    hoverTarget.set(0);
+    rotateXTarget.set(0);
+    rotateYTarget.set(0);
+    pointerX.set(0.5);
+    pointerY.set(0.5);
+    setActive(false);
+  }, [hoverTarget, pointerX, pointerY, rotateXTarget, rotateYTarget]);
+
+  useEffect(() => {
+    return () => {
+      if (frameRef.current) cancelAnimationFrame(frameRef.current);
+    };
+  }, []);
+
+  /* If the pointer capability disappears mid-session (mouse unplugged, or the
+     user turns on Reduce Motion), park the surface flat instead of stranding
+     it mid-tilt. */
+  useEffect(() => {
+    if (!enabled) handlePointerLeave();
+  }, [enabled, handlePointerLeave]);
+
+  const context = useMemo<Tilt3DContextValue>(
+    () => ({ pointerX, pointerY, hover, enabled }),
+    [pointerX, pointerY, hover, enabled],
+  );
+
+  return (
+    <Tilt3DContext.Provider value={context}>
+      <motion.div
+        ref={ref}
+        className={cn('preserve-3d', className)}
+        onPointerMove={enabled ? handlePointerMove : undefined}
+        onPointerEnter={enabled ? handlePointerEnter : undefined}
+        onPointerLeave={enabled ? handlePointerLeave : undefined}
+        style={
+          enabled
+            ? {
+                transformPerspective: perspective,
+                rotateX,
+                rotateY,
+                z,
+                // Only promote to its own layer while the surface is in play,
+                // so a page full of cards doesn't hold compositor memory idle.
+                willChange: active ? 'transform' : undefined,
+              }
+            : undefined
+        }
+      >
+        {children}
+      </motion.div>
+    </Tilt3DContext.Provider>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Depth — lifts content off the tilted surface for parallax.
+   ───────────────────────────────────────────────────────────── */
+
+export interface DepthProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Distance toward the viewer, in px. */
+  z?: number;
+  children: React.ReactNode;
+}
+
+export function Depth({ z = 18, className, children, ...rest }: DepthProps) {
+  const context = useTilt3DContext();
+
+  return (
+    <div
+      className={cn('preserve-3d', className)}
+      style={
+        context?.enabled
+          ? { transform: `translate3d(0, 0, ${z}px)` }
+          : undefined
+      }
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Tilt3DSheen — pointer-tracked specular highlight.
+
+   Renders as a child of the element whose radius it should match
+   (border-radius: inherit), so it never has to know about it.
+   ───────────────────────────────────────────────────────────── */
+
+export function Tilt3DSheen({ className }: { className?: string }) {
+  const context = useTilt3DContext();
+
+  // Stand-ins so the hooks below stay unconditional when rendered outside a
+  // <Tilt3D>; the component bails out before they reach the DOM.
+  const idleX = useMotionValue(0.5);
+  const idleY = useMotionValue(0.5);
+
+  const x = useTransform(
+    context?.pointerX ?? idleX,
+    (value) => `${value * 100}%`,
+  );
+  const y = useTransform(
+    context?.pointerY ?? idleY,
+    (value) => `${value * 100}%`,
+  );
+  // Kept tight on purpose: a wide gradient washes the whole surface and reads
+  // as grime rather than as a highlight.
+  const background = useMotionTemplate`radial-gradient(38% 62% at ${x} ${y}, var(--tilt-sheen), transparent 74%)`;
+
+  if (!context?.enabled) return null;
+
+  return (
+    <motion.span
+      aria-hidden="true"
+      className={cn(
+        'pointer-events-none absolute inset-0 rounded-[inherit]',
+        className,
+      )}
+      style={{ background, opacity: context.hover }}
+    />
+  );
+}

--- a/src/hooks/useFinePointer.ts
+++ b/src/hooks/useFinePointer.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(hover: hover) and (pointer: fine)';
+
+/**
+ * True when the device drives a precise, hovering pointer (mouse / trackpad).
+ *
+ * Deliberately false on the server and during the first client render so
+ * hydration stays stable — pointer-driven 3D is a progressive enhancement that
+ * switches on right after mount, and never runs on touch where there is no
+ * hover state to drive it.
+ */
+export function useFinePointer() {
+  const [finePointer, setFinePointer] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia(QUERY);
+    const handleChange = () => setFinePointer(mq.matches);
+
+    handleChange();
+
+    mq.addEventListener('change', handleChange);
+
+    return () => {
+      mq.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  return finePointer;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -799,6 +799,177 @@ h2 em {
 }
 
 /* ═══════════════════════════════════════
+   3D — depth tokens
+   Declared after the theme blocks above so each theme picks up the
+   variant tuned for its surface luminance.
+═══════════════════════════════════════ */
+
+:root,
+[data-theme='light'] {
+  /* Specular highlight swept across tilted surfaces. Panels are pure white
+     here, so a white glow would be invisible and a desaturated accent tint
+     just reads as a smudge — a pale cool tint reads as glare instead. */
+  --tilt-sheen: rgba(146, 198, 204, 0.3);
+
+  /* Blueprint solid — the drafted volume in the hero */
+  --solid-face: rgba(44, 100, 100, 0.05);
+  --solid-face-front: rgba(44, 100, 100, 0.085);
+  --solid-edge: rgba(44, 100, 100, 0.4);
+  --solid-grid: rgba(44, 100, 100, 0.13);
+  --solid-glow: rgba(44, 100, 100, 0.2);
+  --solid-ink: rgba(44, 100, 100, 0.9);
+
+  /* Shaded sides of extruded type — always darker than --color-accent so the
+     front face still reads as the lit surface. */
+  --extrude-side: #1b4444;
+}
+
+[data-theme='dim'] {
+  --tilt-sheen: rgba(186, 232, 232, 0.1);
+
+  --solid-face: rgba(106, 184, 184, 0.055);
+  --solid-face-front: rgba(106, 184, 184, 0.1);
+  --solid-edge: rgba(106, 184, 184, 0.48);
+  --solid-grid: rgba(106, 184, 184, 0.16);
+  --solid-glow: rgba(106, 184, 184, 0.22);
+  --solid-ink: rgba(122, 196, 196, 0.92);
+
+  --extrude-side: #2a5a5a;
+}
+
+[data-theme='dark'] {
+  --tilt-sheen: rgba(186, 232, 232, 0.12);
+
+  --solid-face: rgba(122, 196, 196, 0.06);
+  --solid-face-front: rgba(122, 196, 196, 0.11);
+  --solid-edge: rgba(122, 196, 196, 0.5);
+  --solid-grid: rgba(122, 196, 196, 0.17);
+  --solid-glow: rgba(122, 196, 196, 0.24);
+  --solid-ink: rgba(122, 196, 196, 0.95);
+
+  --extrude-side: #275252;
+}
+
+/* ═══════════════════════════════════════
+   3D — helpers
+═══════════════════════════════════════ */
+
+/* Keeps descendants in the parent's 3D space instead of flattening them.
+   The chain has to be unbroken, so every node between a rotating plane and
+   a translateZ'd child needs this. */
+.preserve-3d {
+  transform-style: preserve-3d;
+}
+
+.backface-hidden {
+  backface-visibility: hidden;
+}
+
+/* ── Blueprint solid ── */
+
+.solid-face {
+  background-color: var(--solid-face);
+  background-image:
+    linear-gradient(to right, var(--solid-grid) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--solid-grid) 1px, transparent 1px);
+  background-size: 22px 22px;
+  border: 1px solid var(--solid-edge);
+}
+
+.solid-face-front {
+  background-color: var(--solid-face-front);
+}
+
+/* Contact shadow — deliberately a sibling of the rotating group rather than
+   a child, since `filter` would flatten it out of the 3D context. */
+.solid-shadow {
+  background: radial-gradient(closest-side, var(--solid-glow), transparent);
+  filter: blur(7px);
+}
+
+/* ── Sidebar monogram ── */
+
+.logo-scene {
+  perspective: 170px;
+}
+
+.logo-cube {
+  transform: rotateX(-10deg) rotateY(-14deg);
+  transition: transform 480ms cubic-bezier(0.34, 1.32, 0.5, 1);
+}
+
+.group:hover .logo-cube {
+  transform: rotateX(-10deg) rotateY(-104deg);
+}
+
+/* Shading, not new colours: the top catches light and the sides fall away,
+   both still recognisably the accent so the mark keeps its identity while it
+   turns. */
+.logo-face-top {
+  background-color: color-mix(in srgb, var(--color-accent) 78%, white);
+}
+
+.logo-face-side {
+  background-color: color-mix(in srgb, var(--color-accent) 76%, black);
+}
+
+/* Only the face pointing at the viewer carries a letter — a glyph crushed
+   into a 5px sliver reads as a glitch, not as depth. */
+.logo-glyph {
+  transition: opacity 140ms ease 140ms;
+}
+
+.logo-glyph-side {
+  opacity: 0;
+}
+
+.group:hover .logo-glyph-front {
+  opacity: 0;
+}
+
+.group:hover .logo-glyph-side {
+  opacity: 1;
+}
+
+/* Drafting-style orbit guides around the solid */
+.solid-ring {
+  border: 1px dashed var(--solid-edge);
+  border-radius: 9999px;
+  opacity: 0.8;
+}
+
+@keyframes solid-spin {
+  from {
+    transform: rotateY(0deg);
+  }
+  to {
+    transform: rotateY(360deg);
+  }
+}
+
+@keyframes solid-bob {
+  0%,
+  100% {
+    transform: translate3d(0, -5px, 0);
+  }
+  50% {
+    transform: translate3d(0, 5px, 0);
+  }
+}
+
+@keyframes solid-shadow-breathe {
+  0%,
+  100% {
+    transform: scaleX(0.96);
+    opacity: 0.75;
+  }
+  50% {
+    transform: scaleX(1.06);
+    opacity: 1;
+  }
+}
+
+/* ═══════════════════════════════════════
    NO ANIMATION UTILITY
 ═══════════════════════════════════════ */
 


### PR DESCRIPTION
Adds a small set of reusable 3D primitives and uses them in the handful of places where depth actually earns its keep.

## The one decision worth flagging

I built this on **CSS 3D transforms, not WebGL** — no `three.js`, no `react-three-fiber`, no new dependencies. Dropping a ~150KB WebGL runtime onto a blog whose homepage literally says "performance, design systems" felt like the wrong trade, and CSS 3D composites on the GPU anyway. Everything here is transforms plus `motion` values you already had.

If you actually wanted WebGL, say the word and I'll redo the hero object as a real scene — that's the one piece where it would buy something.

## Primitives — `src/components/three-d/`

| | |
|---|---|
| `Tilt3D` | A surface that rotates under the pointer. Perspective is baked into the element's own transform via `transformPerspective`, so it can stay a grid/flex item rather than needing a wrapper. Exposes pointer position through context. |
| `Depth` | Lifts content off a tilted surface for real parallax. Offsets compose when nested, so a card can have a content plane with accents sitting higher still. |
| `Tilt3DSheen` | Pointer-tracked specular highlight. Renders as a child of whatever it should match and picks up the radius via `border-radius: inherit`, so it never has to be told about it. |
| `Cube3D` | Six-face solid, each face pushed out along its own normal. |
| `ExtrudedText` | Stacks glyph copies along -Z to give type a body. Collapses to plain text with zero extra DOM when there's no perspective to render into. |

`Card` grows a `tilt` prop so this is opt-in from the design system rather than bolted on per-usage.

## Where it's applied

- **Hero (lg+)** — a drafted blueprint solid: grid-ruled translucent cube with vertex marks and centre targets, two counter-rotating dashed orbit guides, a contact shadow. Idles on its own and turns to follow the pointer anywhere on the page.
- **Homepage widget cards** — tilt with layered content parallax. Each card's loudest element (the post count, the chess rating) sits highest; the decorative chess board is set *back* behind the content so it reads as printed on the card face.
- **404** — the digits are genuinely extruded, and the whole block turns with the pointer so you can look around the sides of the type. The drag/bounce behaviour is unchanged.
- **Sidebar monogram** — a shaded cube that rolls `J` → `E` on hover. Top face catches light, sides fall away, both still recognisably the accent so the mark keeps its identity mid-turn.
- **Mobile nav** — hinges up off the FAB instead of scaling in.

## Behaviour and performance

- All pointer-driven 3D is gated behind `(hover: hover) and (pointer: fine)` **and** `prefers-reduced-motion`. When either says no, it renders exactly as it did before — verified on a touch viewport and with reduced motion forced.
- Layout is read once per frame inside `requestAnimationFrame`, never per `pointermove`, so dragging across the widget grid can't thrash style recalculation.
- `will-change: transform` is only set while a surface is actually in play, so a page of cards doesn't hold compositor memory idle.
- Depth tokens are per-theme. The light-theme sheen is a pale cool tint rather than an accent tint — a desaturated accent over a white panel reads as grime, a cool one reads as glare.
- No React re-render per frame anywhere; everything rides motion values.

## Verification

- `tsc --noEmit` clean.
- `eslint` clean on every file touched. (`HeroCTA.tsx` still has its pre-existing prettier violations — I reverted the autofix so this PR stays on topic.)
- Full Playwright suite minus visual: **19/19 passing**.
- Screenshotted all three themes at 1440px, plus a 390px touch viewport and a forced-reduced-motion run.

## Worth a look when you review

- Tilt amount is `max = 6°`. Easy to dial.
- The monogram cube's faces keep their `rounded-[6px]`, which leaves a sub-pixel notch at the shared edge mid-roll. Invisible at 1x, visible at 8x. Squaring the faces would remove it at the cost of the mark's silhouette — your call.
- I skipped the segmented control deliberately. You'd just committed "Play around with physical segmented control styles" and I didn't want to paint over fresh work, though a Z-depth press would fit it well if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wvcv5Sg8vVNW5FbVWpFM9M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive 3D tilt and depth effects to cards, widgets, navigation, and error-page elements.
  * Introduced a 3D blueprint visual in the home hero section.
  * Added extruded 3D “404” typography and a 3D cube-style sidebar logo.
  * Added responsive behavior that respects device capabilities and reduced-motion preferences.

* **Style**
  * Enhanced visual theming with new 3D surfaces, shadows, highlights, animations, and depth effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->