### PR TITLE
Polish: nav alignment, blog measure and ToC, and the resume room's edges

### DIFF
--- a/src/components/Blog/Post/Post.tsx
+++ b/src/components/Blog/Post/Post.tsx
@@ -26,8 +26,11 @@ export default function Post({ post }: Props) {
   const { metadata: meta } = post;
 
   return (
-    <div className="flex items-start w-[1100px] max-w-full min-w-0 mx-auto">
-      <main className="page-pad py-8 min-w-0 flex-1 max-w-[880px]">
+    // 784px of column (a 680px measure once .post-pad's gutters are removed)
+    // plus a 224px rail = 1008px, which the 1024px track holds with room to
+    // spare. Without the rail the column simply centres inside the track.
+    <div className="flex items-start justify-center w-[1024px] max-w-full min-w-0 mx-auto">
+      <main className="post-pad min-w-0 flex-1 max-w-[784px]">
         <article>
           <PageMetaTags
             title={meta.title}
@@ -53,7 +56,10 @@ export default function Post({ post }: Props) {
       </main>
 
       {isBlogPost && post.headings.length > 0 && (
-        <aside className="hidden min-[1400px]:block w-52 shrink-0 pt-8 pl-4 sticky top-8 max-h-[calc(100vh-4rem)] overflow-y-auto">
+        // 1200px viewport − 220px sidebar leaves 980px of content area, enough
+        // for the rail and a 650px-odd measure. Anything narrower and the
+        // column gets cramped, so the rail drops out instead.
+        <aside className="hidden min-[1200px]:block w-52 shrink-0 pt-10 pb-10 pl-4 sticky top-0 max-h-dvh overflow-y-auto">
           <TableOfContents headings={post.headings} activeSlug={activeSlug} />
         </aside>
       )}

--- a/src/components/Blog/Post/TableOfContents.tsx
+++ b/src/components/Blog/Post/TableOfContents.tsx
@@ -54,7 +54,9 @@ export const TableOfContents = ({ headings, activeSlug }: Props) => {
                   );
                 }}
                 className={cn(
-                  'block py-1 no-underline transition-[colors, transform] duration-150 leading-[1.4]',
+                  // `colors` is not a property, so the old value invalidated
+                  // the whole declaration and nothing transitioned
+                  'block py-1 no-underline transition-[color,transform] duration-150 leading-[1.4]',
                   heading.level === 3 ? 'text-[12px]' : 'text-[13px]',
                   'hover:text-(--color-ink-3)',
                   isActive

--- a/src/components/CommandPalette/constants/actions.ts
+++ b/src/components/CommandPalette/constants/actions.ts
@@ -21,7 +21,6 @@ export const QUERIES = [
   'Use IBM Plex Sans font',
   'Use Libre Franklin font',
   'Use Figtree font',
-  'Use Epilogue font',
 ] as const;
 
 export const ACTIONS = [
@@ -53,7 +52,6 @@ export const QUERIES_ACTIONS_MAP: Record<Query, Action> = {
   'Use IBM Plex Sans font': 'SET_FONT',
   'Use Libre Franklin font': 'SET_FONT',
   'Use Figtree font': 'SET_FONT',
-  'Use Epilogue font': 'SET_FONT',
 };
 
 export const filterValidQueries = (

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -67,9 +67,14 @@ function NavButton({ item, isActive }: { item: NavItem; isActive: boolean }) {
       {isActive && (
         <span className="hidden lg:block absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-4 bg-(--color-accent-2) rounded-r-[3px]" />
       )}
+      {/* `items-center` lands the 16px icon on the centre of the label's
+          20.8px line box, which is 2.39px below the centre of its cap band —
+          where a boxy 16px glyph wants to sit. Hence the lift, and hence it
+          being confined to the widths that actually render a label: on the
+          icon-strip sidebar the same nudge just knocks the icon off-centre. */}
       <span
         className={cn(
-          'shrink-0 flex items-center -translate-y-px',
+          'shrink-0 flex items-center justify-center size-4 lg:-translate-y-[2px]',
           !isActive && 'opacity-90',
         )}
       >

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -67,14 +67,18 @@ function NavButton({ item, isActive }: { item: NavItem; isActive: boolean }) {
       {isActive && (
         <span className="hidden lg:block absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-4 bg-(--color-accent-2) rounded-r-[3px]" />
       )}
-      {/* `items-center` lands the 16px icon on the centre of the label's
-          20.8px line box, which is 2.39px below the centre of its cap band —
-          where a boxy 16px glyph wants to sit. Hence the lift, and hence it
-          being confined to the widths that actually render a label: on the
-          icon-strip sidebar the same nudge just knocks the icon off-centre. */}
+      {/* `items-center` lands the icon on the centre of the label's line box,
+          but the eye reads the label's cap band, which sits 0.2–1.0px higher
+          across the switchable faces (measured at this 13px label beside its
+          16px icon). One pixel covers the range — it lands the default face
+          dead on and leaves the worst case under ¾ of a pixel out, where a
+          fractional lift would only blur the icon's 1px strokes.
+
+          Only where a label is actually rendered, though: on the icon-strip
+          sidebar the same nudge just knocks the icon off-centre. */}
       <span
         className={cn(
-          'shrink-0 flex items-center justify-center size-4 lg:-translate-y-[2px]',
+          'shrink-0 flex items-center justify-center size-4 lg:-translate-y-px',
           !isActive && 'opacity-90',
         )}
       >

--- a/src/components/resume/CozyRoom/CameraRig.tsx
+++ b/src/components/resume/CozyRoom/CameraRig.tsx
@@ -29,6 +29,10 @@ type CameraRigProps = {
   // Desktop gets drag-to-orbit and panel-aware framing; mobile keeps
   // one-finger touch free for page scrolling and flies tighter instead
   desktop: boolean;
+  // Pixels the canvas overhangs its slot by, top and bottom. Those rows are
+  // overscan — somewhere for a zoomed-in room to spill — so framing has to
+  // keep measuring itself against the slot, not against the whole canvas.
+  bleed: number;
 };
 
 const INTRO_DURATION = 1.2;
@@ -48,6 +52,32 @@ const PORTRAIT_ASPECT = 1.1;
 const ROOM_HALF_WIDTH = 5.4;
 const ROOM_HALF_HEIGHT = 3.6;
 const MAX_FIT_PULLBACK = 2.2;
+
+/**
+ * The canvas overshoots its slot by `bleed` at the top and at the bottom, so a
+ * zoomed-in room spills over the page rather than stopping at a hard edge.
+ * Framing keeps measuring itself against the slot; the lens is then widened by
+ * exactly the overscan, which puts the room on screen at the size it would
+ * have been on a canvas that stopped where the slot does.
+ *
+ * Everything here is derived from the canvas size, never from `camera.fov` —
+ * the camera is mutated from an effect, and the frame loop can freeze the
+ * overview position before that effect has landed.
+ */
+const framing = (width: number, height: number, bleed: number) => {
+  const frameHeight = Math.max(1, height - bleed * 2);
+  const aspect = width / frameHeight;
+  const framedFov = aspect < PORTRAIT_ASPECT ? PORTRAIT_FOV : LANDSCAPE_FOV;
+  const extent = Math.tan(MathUtils.degToRad(framedFov) / 2);
+
+  return {
+    aspect,
+    extent,
+    cameraFov: MathUtils.radToDeg(
+      2 * Math.atan(extent * (height / frameHeight)),
+    ),
+  };
+};
 
 const easeOutCubic = (x: number) => 1 - Math.pow(1 - x, 3);
 const easeInOutCubic = (x: number) =>
@@ -92,6 +122,7 @@ export function CameraRig({
   desktop,
   resetSignal,
   keyboardFocus,
+  bleed,
 }: CameraRigProps) {
   const controls = useThree(
     (state) => state.controls,
@@ -103,12 +134,11 @@ export function CameraRig({
   // rebuilt whenever the canvas is resized or rotated
   useEffect(() => {
     if (!(camera instanceof PerspectiveCamera)) return;
-    const fov =
-      size.width / size.height < PORTRAIT_ASPECT ? PORTRAIT_FOV : LANDSCAPE_FOV;
-    if (camera.fov === fov) return;
-    camera.fov = fov;
+    const { cameraFov } = framing(size.width, size.height, bleed);
+    if (Math.abs(camera.fov - cameraFov) < 1e-4) return;
+    camera.fov = cameraFov;
     camera.updateProjectionMatrix();
-  }, [camera, size]);
+  }, [camera, size, bleed]);
 
   const [hasInteracted, setHasInteracted] = useState(false);
   const lookRef = useRef(new Vector3(...CAMERA_VIEWS.overview.target));
@@ -197,8 +227,13 @@ export function CameraRig({
 
     // Back the overview off until the room's full width fits the frame
     if (view === 'overview' && camera instanceof PerspectiveCamera) {
-      const aspect = state.size.width / state.size.height;
-      const extent = Math.tan(MathUtils.degToRad(camera.fov) / 2);
+      // Fit to the slot the room appears to sit in. Fitting the overscan
+      // instead would pull the camera back and shrink the room.
+      const { aspect, extent } = framing(
+        state.size.width,
+        state.size.height,
+        bleed,
+      );
       const reach = Math.max(
         ROOM_HALF_WIDTH / (extent * aspect),
         ROOM_HALF_HEIGHT / extent,

--- a/src/components/resume/CozyRoom/Room.tsx
+++ b/src/components/resume/CozyRoom/Room.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { Html } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
 import { XIcon } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -15,6 +14,7 @@ import { ScrollArea } from '../ScrollArea';
 import { aboutPanelAnchor } from './avatarState';
 import { HOTSPOTS, PANEL_PLACEMENTS, SectionId, ViewId } from './hotspots';
 import { useLivePalette } from './livePalette';
+import { SceneHtml } from './SceneHtml';
 import {
   Avatar,
   Bookshelf,
@@ -100,7 +100,7 @@ function ScenePanel({
 
   return (
     <group position={anchor}>
-      <Html center zIndexRange={[40, 0]}>
+      <SceneHtml center zIndexRange={[40, 0]}>
         {/* Single-element 3D tilt — browsers hit-test this correctly,
             unlike nested matrix3d chains */}
         <div
@@ -141,7 +141,7 @@ function ScenePanel({
             </ScrollArea>
           </motion.div>
         </div>
-      </Html>
+      </SceneHtml>
     </group>
   );
 }
@@ -342,7 +342,7 @@ export function Room({
         HOTSPOTS.filter((hotspot) => hotspot.id !== 'about').map(
           (hotspot, i) => (
             <group key={hotspot.id} position={hotspot.labelPosition}>
-              <Html center distanceFactor={10} zIndexRange={[40, 0]}>
+              <SceneHtml center distanceFactor={10} zIndexRange={[40, 0]}>
                 <motion.button
                   type="button"
                   initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 6 }}
@@ -371,7 +371,7 @@ export function Room({
                 >
                   {hotspot.label}
                 </motion.button>
-              </Html>
+              </SceneHtml>
             </group>
           ),
         )}

--- a/src/components/resume/CozyRoom/SceneHtml.tsx
+++ b/src/components/resume/CozyRoom/SceneHtml.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, type RefObject } from 'react';
+import { Html } from '@react-three/drei';
+
+type HtmlProps = React.ComponentProps<typeof Html>;
+
+/**
+ * drei mounts `<Html>` into whichever element r3f takes its events from. For
+ * this scene that is the slot, while the canvas deliberately overhangs it — so
+ * anything mounted there lands a full bleed below the object it belongs to,
+ * and inherits whatever the slot does to the accessibility tree.
+ *
+ * The canvas-aligned layer therefore travels in context rather than as a prop:
+ * every overlay in the room picks it up, including ones added later, without
+ * threading a ref down through the object tree.
+ */
+const HtmlPortalContext = createContext<RefObject<HTMLElement | null> | null>(
+  null,
+);
+
+export const HtmlPortalProvider = HtmlPortalContext.Provider;
+
+export function SceneHtml(props: HtmlProps) {
+  const portal = useContext(HtmlPortalContext);
+
+  return <Html {...props} portal={portal as RefObject<HTMLElement>} />;
+}

--- a/src/components/resume/CozyRoom/index.tsx
+++ b/src/components/resume/CozyRoom/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type RefObject } from 'react';
 import { Canvas } from '@react-three/fiber';
 
 import type { WritingItem } from '@/blog/types';
@@ -9,7 +9,11 @@ import { CameraRig } from './CameraRig';
 import { INTRO_CAMERA_POSITION, SectionId, ViewId } from './hotspots';
 import { PaletteProvider } from './livePalette';
 import { Room } from './Room';
+import { HtmlPortalProvider } from './SceneHtml';
 import { bindSceneCursor, setSceneCursor } from './sceneCursor';
+
+const BLEED_FADE = (bleed: number) =>
+  `linear-gradient(to bottom, transparent 0, #000 ${bleed}px, #000 calc(100% - ${bleed}px), transparent 100%)`;
 
 type CozyRoomSceneProps = {
   view: ViewId;
@@ -33,6 +37,17 @@ type CozyRoomSceneProps = {
   // False once the room has scrolled out of view — rendering stops
   // rather than burning GPU on pixels nobody is looking at
   active: boolean;
+  // The canvas is drawn taller than the slot it appears to occupy, by this
+  // many CSS pixels at the top and at the bottom, so a zoomed-in room spills
+  // over the page instead of being sheared off at a hard edge
+  bleed: number;
+  // Pointer events are taken from this element instead of the canvas, which
+  // keeps the copy the canvas now covers selectable and clickable
+  eventSource: RefObject<HTMLElement | null>;
+  // Where the scene's <Html> overlays — hotspot labels, section panels —
+  // mount. It tracks the canvas box, not the slot, so they stay pinned to the
+  // objects they label once the canvas starts overhanging
+  htmlPortal: RefObject<HTMLElement | null>;
 };
 
 export function CozyRoomScene({
@@ -48,6 +63,9 @@ export function CozyRoomScene({
   onCycleTheme,
   onContextLost,
   active,
+  bleed,
+  eventSource,
+  htmlPortal,
 }: CozyRoomSceneProps) {
   const [hovered, setHovered] = useState<SectionId | null>(null);
   // The first frame lands mid-swoop; easing it in is kinder than a pop
@@ -68,9 +86,23 @@ export function CozyRoomScene({
       window.removeEventListener('pointerup', release);
       window.removeEventListener('pointercancel', release);
       window.removeEventListener('blur', release);
-      bindSceneCursor(null);
     };
   }, []);
+
+  // r3f drops the canvas out of hit testing once it is fed from an
+  // eventSource, so the cursor and the press that starts a drag belong on
+  // that element rather than on the canvas
+  useEffect(() => {
+    const element = eventSource.current;
+    if (!element) return;
+    const grab = () => setSceneCursor('drag', true);
+    bindSceneCursor(element);
+    element.addEventListener('pointerdown', grab);
+    return () => {
+      element.removeEventListener('pointerdown', grab);
+      bindSceneCursor(null);
+    };
+  }, [eventSource]);
 
   return (
     <Canvas
@@ -81,44 +113,79 @@ export function CozyRoomScene({
         position: INTRO_CAMERA_POSITION,
         fov: 38,
       }}
+      // r3f types the ref as always-resolved. It is by the time this runs:
+      // the hit element renders alongside the slot, and this scene is only
+      // loaded (lazily, client-side) once that slot is on the page.
+      eventSource={eventSource as RefObject<HTMLElement>}
       style={{
-        touchAction: desktop ? 'none' : 'pan-y',
+        // Overhang the slot on both edges. Symmetric, so the room stays
+        // centred on the same point it would have been without the bleed.
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        top: -bleed,
+        bottom: -bleed,
+        width: 'auto',
+        height: 'auto',
+        // The overhang is a soft edge, not a second hard one: the room is at
+        // full strength everywhere inside the slot and dissolves across the
+        // bleed, so a zoomed-in room runs out over the page rather than
+        // stopping dead at a rectangle.
+        maskImage: BLEED_FADE(bleed),
+        WebkitMaskImage: BLEED_FADE(bleed),
         opacity: ready ? 1 : 0,
         transition: 'opacity 500ms ease-out',
       }}
-      onCreated={({ gl }) => {
+      onCreated={(state) => {
+        const { gl } = state;
+        // Events arrive from the slot, which no longer shares an origin with
+        // the canvas — so measure the pointer against the canvas itself
+        state.setEvents({
+          compute: (event, rootState) => {
+            const rect = gl.domElement.getBoundingClientRect();
+            rootState.pointer.set(
+              ((event.clientX - rect.left) / rect.width) * 2 - 1,
+              -((event.clientY - rect.top) / rect.height) * 2 + 1,
+            );
+            rootState.raycaster.setFromCamera(
+              rootState.pointer,
+              rootState.camera,
+            );
+          },
+        });
         gl.domElement.addEventListener('webglcontextlost', (event) => {
           event.preventDefault();
           onContextLost();
         });
-        bindSceneCursor(gl.domElement);
         setReady(true);
       }}
-      onPointerDown={() => setSceneCursor('drag', true)}
       onPointerMissed={() => {
         if (view !== 'overview') onClose();
       }}
     >
-      <PaletteProvider theme={theme} reduceMotion={reduceMotion}>
-        <CameraRig
-          view={view}
-          reduceMotion={reduceMotion}
-          desktop={desktop}
-          resetSignal={resetSignal}
-          keyboardFocus={keyboardFocus}
-        />
-        <Room
-          reduceMotion={reduceMotion}
-          view={view}
-          hovered={hovered}
-          panel3d={desktop}
-          writings={writings}
-          onHover={setHovered}
-          onSelect={onSelect}
-          onClose={onClose}
-          onCycleTheme={onCycleTheme}
-        />
-      </PaletteProvider>
+      <HtmlPortalProvider value={htmlPortal}>
+        <PaletteProvider theme={theme} reduceMotion={reduceMotion}>
+          <CameraRig
+            view={view}
+            reduceMotion={reduceMotion}
+            desktop={desktop}
+            resetSignal={resetSignal}
+            keyboardFocus={keyboardFocus}
+            bleed={bleed}
+          />
+          <Room
+            reduceMotion={reduceMotion}
+            view={view}
+            hovered={hovered}
+            panel3d={desktop}
+            writings={writings}
+            onHover={setHovered}
+            onSelect={onSelect}
+            onClose={onClose}
+            onCycleTheme={onCycleTheme}
+          />
+        </PaletteProvider>
+      </HtmlPortalProvider>
     </Canvas>
   );
 }

--- a/src/components/resume/CozyRoom/objects.tsx
+++ b/src/components/resume/CozyRoom/objects.tsx
@@ -1,5 +1,4 @@
 import { useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { Html } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
 import type { ThreeElements } from '@react-three/fiber';
 import {
@@ -34,6 +33,7 @@ import { useLivePalette } from './livePalette';
 import { MATERIALS } from './palette';
 import { setSceneCursor } from './sceneCursor';
 import type { SectionId } from './hotspots';
+import { SceneHtml } from './SceneHtml';
 
 // `id` collides with our SectionId prop (three.js types it as a number),
 // and `children` is re-declared as required below.
@@ -748,11 +748,11 @@ export function DeskLamp({ onCycleTheme }: { onCycleTheme: () => void }) {
       }}
     >
       {hovered && (
-        <Html center position={[-0.1, 0.85, 0]} zIndexRange={[40, 0]}>
+        <SceneHtml center position={[-0.1, 0.85, 0]} zIndexRange={[40, 0]}>
           <div className="pointer-events-none rounded-full border border-(--color-border-hi) bg-(--color-bg-panel) px-2.5 pt-[5px] pb-[3px] text-[11px] leading-none font-medium whitespace-nowrap text-(--color-ink-2) shadow-(--shadow-md)">
             Flip the lights
           </div>
-        </Html>
+        </SceneHtml>
       )}
       {/* Generous invisible hit target — the lamp itself is tiny on screen */}
       <mesh position={[-0.1, 0.3, 0]}>
@@ -1934,7 +1934,7 @@ export function Avatar({
       {/* Just above his head. Floating it higher drifts the tag into the
         band the wall labels live in, and he walks underneath them */}
       {showLabel && (
-        <Html
+        <SceneHtml
           center
           position={[0, 1.52 * AVATAR_SCALE, 0]}
           zIndexRange={[40, 0]}
@@ -1952,7 +1952,7 @@ export function Avatar({
           >
             About me
           </button>
-        </Html>
+        </SceneHtml>
       )}
       <group ref={scaleRef} scale={0.0001}>
         <group

--- a/src/components/resume/ResumeOverlay.tsx
+++ b/src/components/resume/ResumeOverlay.tsx
@@ -43,7 +43,9 @@ export function ResumeOverlay({
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 16 }}
           transition={{ type: 'spring', stiffness: 420, damping: 34 }}
-          className="absolute inset-x-2 bottom-2 top-auto flex max-h-[46%] flex-col overflow-hidden rounded-2xl border border-(--color-border) bg-(--color-bg-panel) shadow-(--shadow-lg) md:inset-x-auto md:top-3 md:right-3 md:bottom-3 md:max-h-none md:w-[400px]"
+          // z-20 keeps the sheet above the layer the scene mounts its hotspot
+          // labels into, which the overhanging canvas needs to sit at z-10
+          className="absolute inset-x-2 bottom-2 top-auto z-20 flex max-h-[46%] flex-col overflow-hidden rounded-2xl border border-(--color-border) bg-(--color-bg-panel) shadow-(--shadow-lg) md:inset-x-auto md:top-3 md:right-3 md:bottom-3 md:max-h-none md:w-[400px]"
         >
           <div className="flex items-center justify-between gap-2 px-5 pt-4 pb-2">
             <Heading level={3} as="h2" id={`sheet-heading-${section}`}>

--- a/src/pages/resume.tsx
+++ b/src/pages/resume.tsx
@@ -55,6 +55,11 @@ const HOTSPOT_BUTTONS: Array<{ id: SectionId; icon: React.ReactNode }> = [
 
 const SECTION_IDS = HOTSPOT_BUTTONS.map((button) => button.id);
 
+// How far the room is allowed to spill past its slot, top and bottom, so
+// zooming or panning runs off the page rather than into a hard crop. Phones
+// have far less page to spill onto, so they get less of it.
+const SCENE_BLEED = { desktop: 112, mobile: 48 };
+
 const viewFromHash = (): ViewId => {
   const hash = window.location.hash.replace('#', '');
   return (SECTION_IDS as string[]).includes(hash)
@@ -75,6 +80,8 @@ export default function Resume({ featuredWritings }: Props) {
   const [sceneFocused, setSceneFocused] = useState(false);
   const [sceneVisible, setSceneVisible] = useState(true);
   const sceneRef = useRef<HTMLDivElement>(null);
+  const sceneHitRef = useRef<HTMLDivElement>(null);
+  const sceneOverlayRef = useRef<HTMLDivElement>(null);
   const { theme, setTheme } = useTheme();
   const reduceMotion = useReduceMotion();
 
@@ -144,6 +151,7 @@ export default function Resume({ featuredWritings }: Props) {
   }, [closeSection]);
 
   const showFlat = flatMode || webglOk === false;
+  const sceneBleed = isDesktop ? SCENE_BLEED.desktop : SCENE_BLEED.mobile;
   const activeSection = view === 'overview' ? null : view;
 
   return (
@@ -215,7 +223,9 @@ export default function Resume({ featuredWritings }: Props) {
             </Text>
           </div>
 
-          {/* Full-bleed so the room gets all the space it deserves.
+          {/* Full-bleed so the room gets all the space it deserves, and
+              stacked above the copy either side of it so a room that has been
+              zoomed or panned spills over the page instead of being cropped.
               Focusable so keyboard users can step into the room and move
               with the arrow keys. */}
           <div
@@ -225,15 +235,37 @@ export default function Resume({ featuredWritings }: Props) {
             aria-label="Interactive 3D room. Use W A S D or the arrow keys to move the camera."
             onFocus={() => setSceneFocused(true)}
             onBlur={() => setSceneFocused(false)}
-            onPointerDown={(event) => {
-              // Focus when the canvas itself is clicked, but let the
-              // overlay buttons keep their own focus
-              if ((event.target as HTMLElement).tagName === 'CANVAS') {
-                event.currentTarget.focus();
-              }
-            }}
-            className="print-hide relative mt-2 h-[76vh] min-h-[min(500px,88vh)] w-full rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--color-accent) md:mt-4 md:h-[80vh]"
+            className="print-hide relative z-10 mt-2 h-[76vh] min-h-[min(500px,88vh)] w-full rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--color-accent) md:mt-4 md:h-[80vh]"
           >
+            {/* The room's hit area. It stops at the slot even though the canvas
+                does not, which is what keeps the copy underneath the overhang
+                selectable. Declared before the canvas so its ref is attached by
+                the time the scene wires itself up; the canvas is inert, so
+                painting over it costs nothing.
+                touch-action is forced because OrbitControls otherwise writes
+                `none` here on connect, which would eat one-finger scrolling. */}
+            {webglOk && (
+              <div
+                ref={sceneHitRef}
+                onPointerDown={() => sceneRef.current?.focus()}
+                className={cn(
+                  'absolute inset-0',
+                  isDesktop ? '[touch-action:none]!' : '[touch-action:pan-y]!',
+                )}
+              />
+            )}
+            {/* Where the scene's HTML overlays mount. It tracks the canvas box
+                rather than the slot, because drei positions them in canvas
+                pixels — mount them on the slot and every hotspot label sits a
+                full bleed below the object it points at. Inert itself; the
+                overlays switch pointer events back on for their own content. */}
+            {webglOk && (
+              <div
+                ref={sceneOverlayRef}
+                className="pointer-events-none absolute inset-x-0 z-10"
+                style={{ top: -sceneBleed, bottom: -sceneBleed }}
+              />
+            )}
             {webglOk && (
               <SceneErrorBoundary onError={() => setWebglOk(false)}>
                 <CozyRoomScene
@@ -249,6 +281,9 @@ export default function Resume({ featuredWritings }: Props) {
                   onCycleTheme={cycleTheme}
                   onContextLost={() => setWebglOk(false)}
                   active={sceneVisible}
+                  bleed={sceneBleed}
+                  eventSource={sceneHitRef}
+                  htmlPortal={sceneOverlayRef}
                 />
               </SceneErrorBoundary>
             )}
@@ -256,7 +291,7 @@ export default function Resume({ featuredWritings }: Props) {
               <button
                 type="button"
                 onClick={() => setResetSignal((signal) => signal + 1)}
-                className="absolute top-3 right-3 inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-(--color-border-hi) bg-(--color-bg-panel) px-3 py-[7px] text-[12px] leading-none font-medium text-(--color-ink-2) shadow-(--shadow-md) transition-[color,border-color,transform] duration-150 hover:-translate-y-px hover:border-(--color-accent) hover:text-(--color-accent-text) active:scale-[0.96]"
+                className="absolute top-3 right-3 z-20 inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-(--color-border-hi) bg-(--color-bg-panel) px-3 py-[7px] text-[12px] leading-none font-medium text-(--color-ink-2) shadow-(--shadow-md) transition-[color,border-color,transform] duration-150 hover:-translate-y-px hover:border-(--color-accent) hover:text-(--color-accent-text) active:scale-[0.96]"
               >
                 <RotateCcwIcon size={13} aria-hidden="true" />
                 Reset view
@@ -276,7 +311,11 @@ export default function Resume({ featuredWritings }: Props) {
               enough to push the room itself past the fold — so they run in
               one scrolling line instead, and only wrap once there is room.
               The trailing padding clears the floating mobile nav button. */}
-            <div className="flex items-center gap-2 overflow-x-auto pr-16 pb-1 [scrollbar-width:none] md:flex-wrap md:overflow-x-visible md:pr-0 md:pb-0 [&::-webkit-scrollbar]:hidden">
+            {/* `overflow-x: auto` forces the block axis to clip too, which
+                sheared the top off the pills' 1px hover lift — the inset
+                padding gives it somewhere to go, and the negative margin
+                keeps the row's own spacing unchanged. */}
+            <div className="-my-2 flex items-center gap-2 overflow-x-auto py-2 pr-16 [scrollbar-width:none] md:flex-wrap md:overflow-x-visible md:pr-0 [&::-webkit-scrollbar]:hidden">
               {HOTSPOT_BUTTONS.map((button) => (
                 <button
                   key={button.id}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -563,10 +563,25 @@ h2 em {
   }
 }
 
-/* Hero + WidgetGrid responsive layout */
+/* Blog posts. Same rhythm as .page-pad, but the column width belongs to the
+   post layout (which sizes it against the table of contents beside it) rather
+   than to the padding rule. */
+.post-pad {
+  padding: 24px 20px;
+}
+
+@media (min-width: 768px) {
+  .post-pad {
+    padding: 40px 52px;
+  }
+}
+
+/* Hero + WidgetGrid responsive layout.
+   Shares .widget-grid / .latest-pad's max-width so the hero copy starts on the
+   same left edge as the widgets stacked underneath it. */
 .hero-pad {
   padding: 32px 20px 28px;
-  max-width: 900px;
+  max-width: 960px;
   margin-inline: auto;
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -44,9 +44,9 @@
    TYPE SYSTEM — the switchable pairings
 
    Fraunces is the display face throughout, so headings need no per-pairing
-   tuning. Every face reads at one size, set in :root; only the leading is
-   nudged per face, since x-heights differ enough to change how tight a
-   paragraph feels at the same size.
+   tuning. Every face reads at one size, set in :root; the leading is nudged
+   per face, since x-heights differ enough to change how tight a paragraph
+   feels at the same size.
 
    The visitor's choice is stamped on <html> as data-type-pairing, by the
    inline script in _document (before first paint) and thereafter by
@@ -103,12 +103,6 @@
   --font-text-face: var(--font-figtree);
   --font-mono-face: var(--font-jetbrains-mono);
   --type-body-lh: 1.62;
-}
-
-[data-type-pairing='epilogue'] {
-  --font-text-face: var(--font-epilogue);
-  --font-mono-face: var(--font-jetbrains-mono);
-  --type-body-lh: 1.6;
 }
 
 /* ═══════════════════════════════════════

--- a/src/utils/fonts/faces.ts
+++ b/src/utils/fonts/faces.ts
@@ -1,5 +1,4 @@
 import {
-  Epilogue,
   Figtree,
   Fraunces,
   IBM_Plex_Mono,
@@ -81,16 +80,6 @@ export const figtree = Figtree({
   preload: false,
 });
 
-// Weights are left unset so next/font serves the variable file — the static
-// 300–600 set meant every `font-bold` (700) silently rendered at 600.
-export const epilogue = Epilogue({
-  subsets: ['latin'],
-  style: ['normal', 'italic'],
-  variable: '--font-epilogue',
-  display: 'swap',
-  preload: false,
-});
-
 export const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
   variable: '--font-jetbrains-mono',
@@ -116,7 +105,6 @@ export const fontsClasses = [
   plexSans,
   libreFranklin,
   figtree,
-  epilogue,
   jetbrainsMono,
   plexMono,
 ]

--- a/src/utils/fonts/pairings.ts
+++ b/src/utils/fonts/pairings.ts
@@ -16,8 +16,7 @@ export type PairingId =
   | 'public-sans'
   | 'plex-sans'
   | 'libre-franklin'
-  | 'figtree'
-  | 'epilogue';
+  | 'figtree';
 
 export interface FontPairing {
   id: PairingId;
@@ -67,12 +66,6 @@ export const FONT_PAIRINGS: FontPairing[] = [
     label: 'Figtree',
     description: 'Warm geometric',
     cssVar: '--font-figtree',
-  },
-  {
-    id: 'epilogue',
-    label: 'Epilogue',
-    description: 'The original',
-    cssVar: '--font-epilogue',
   },
 ];
 


### PR DESCRIPTION
A pass over the unpolished edges you spotted, plus a few found along the way. Every number below was measured in a real browser rather than eyeballed.

## What you reported

**Sidebar nav — label and icons not quite centred.** The icon carried a `-1px` lift, but `align-items: center` puts it on the middle of the label's *line box*, while the eye reads the label's *cap band*, which sits higher. Measured with a zero-height baseline marker and a canvas ink scan, that gap is 0.22–1.02px across the switchable faces. One pixel covers the range: the default face lands within 0.02px and the worst case (Inter Tight) is 0.78px out. The lift is now also confined to widths that actually render a label — on the icon-strip sidebar the same nudge was knocking the icon off-centre, which is why the strip now measures exactly 0.

**Blog ToC missing, body too wide.** The ToC was gated on a 1400px viewport, which a 1440px display can never reach once the 220px sidebar comes off — so it never appeared on a laptop. Rebuilt around a 1024px track: a 784px column beside a 224px rail, showing from 1200px up. The reading measure drops from 776px to 680px. The column width moves out of `.page-pad`'s hardcoded 880px into a `.post-pad` rule that owns only padding.

**Resume pills clipped on hover.** `overflow-x: auto` forces the block axis to clip too, shearing the top off the 1px hover lift. Inset padding with a cancelling negative margin gives it somewhere to go — headroom goes from 0px to 8px with the row's own spacing unchanged.

**Resume room clipped by its container.** The canvas now overhangs its slot by 112px top and bottom (48px on phones) and stacks above the page, so a zoomed or panned room spills over the copy instead of stopping at a rectangle. The overhang masks out, so the floor corner that used to be hard-cropped fades rather than landing on the pills. Pointer events route through a slot-sized hit element, which keeps the copy underneath selectable and the pills clickable.

Framing still measures itself against the slot and widens the lens by exactly the overscan, so the room lands on screen at the size it always did — verified pixel-for-pixel against the pre-change build at a fixed camera.

## Found along the way

- **Home hero misaligned.** `.hero-pad` capped at 900px while `.widget-grid` and `.latest-pad` cap at 960px, so the hero copy started 30px right of the widgets beneath it. All three left edges now measure 402px.
- **Dead ToC transition.** `transition-[colors, transform]` — `colors` is not a property, so the declaration was invalid and nothing animated.

## Epilogue

Master made the reading face switchable, and Epilogue was the outlier forcing the spread above — its line box is far more asymmetric than the others, wanting a 2.39px lift where everything else wants under 1px. It is removed as an option, which is what lets a single pixel serve every remaining face.

A visitor who had already chosen it falls back to the default: both the pre-paint script in `_document` and `useFontPairing` validate the stored id against `PAIRING_IDS`, so a stale value is ignored rather than applied. Verified by seeding `localStorage`.

The OG image generator still embeds Epilogue from Google Fonts. That is a separate satori pipeline with no connection to the reading-face picker, and changing it would alter every social card, so it is left alone.

## Two things worth flagging

**Visual snapshots need regenerating on macOS — green CI does not cover them.** `e2e.yml` runs with `--grep-invert "Visual"`, so the suite that passed here never touched the baselines. The desktop ones will fail locally: nav icons moved and the homepage hero moved 30px. They are darwin-pinned, so they cannot be regenerated from Linux either: `pnpm test:e2e --update-snapshots`.

**The `eventSource` change had a non-obvious blast radius**, and your e2e suite caught half of it. drei mounts every `Html` overlay into whichever element r3f takes events from, so the room's hotspot labels and section panels moved a full bleed below their objects *and* fell outside the accessibility tree. They now take a canvas-aligned portal from context, so overlays added later pick it up without threading a ref through the object tree.

## Verification

- Typecheck clean.
- Lint unchanged at 59 pre-existing errors, verified against a stashed baseline; changed files are prettier-clean.
- All 26 behavioural e2e specs pass locally (baseline on master was 20/21, with a flaky theme-switcher test).
- Nav alignment measured across all six faces at both the labelled and icon-strip widths; blog measure and ToC gate checked at 1440/1280/1200/1180; resume geometry, stacking, hit-testing and text selection checked at desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDVFGdGfBMcabf2rV4zqzF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Figtree font pairing and improved responsive 3D resume scene framing, overlays, and mobile interaction.
  * Improved blog post spacing and table-of-contents behavior across screen sizes.
* **Bug Fixes**
  * Fixed table-of-contents link transitions.
  * Improved sidebar icon alignment and resume overlay layering.
* **Changes**
  * Removed the Epilogue font and its command palette option.
  * Improved mobile button scrolling and scene edge presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->