### PR TITLE
Hold the ink ramp to the contrast it promises, and pin the mobile tab strip

### DIFF
--- a/docs/frontend-conventions.md
+++ b/docs/frontend-conventions.md
@@ -83,13 +83,29 @@ Key tokens:
 | `--color-border-hi` | High-contrast border |
 | `--color-ink` | Primary text / headings (~12-14:1 contrast) |
 | `--color-ink-2` | Body text (~8-11:1 contrast) |
-| `--color-ink-3` | Secondary / meta text (≥4.5:1, WCAG AA) |
-| `--color-ink-4` | Decorative / placeholder (~2.2-2.5:1) |
+| `--color-ink-3` | Secondary / meta text (≥4.8:1, WCAG AA) |
+| `--color-ink-4` | Decorative only — never text (~2.4-3.2:1) |
 | `--color-accent` | Teal accent (bg) |
 | `--color-accent-text` | Teal accent (text/icons) |
 | `--color-accent-l`, `--color-accent-xl` | Tinted accent fills |
 | `--color-success` | `#4caf84` — green status |
 | `--shadow-sm`, `--shadow-md`, `--shadow-lg` | Elevation shadows |
+
+### The ink-4 rule
+
+`--color-ink-4` sits around 2.4-3.2:1. That is below AA on every surface, deliberately —
+it is the tier for things the eye should register but not read: separator dots, sparkline
+fills, decorative icons, disabled marks.
+
+**If a reader has to read it, it does not go on `ink-4`.** Control labels, links,
+navigation items, group headings and meta lines belong on `ink-3` or above. Note that an
+11px uppercase label still counts as small text under WCAG, so "it's only a caption" is
+not an exemption.
+
+`e2e/contrast.spec.ts` enforces the AA floor for `ink`, `ink-2`, `ink-3` and
+`accent-text` against all five surfaces in all three themes, and checks that the ramp
+stays monotonic. It cannot tell whether a given `ink-4` is decorative or a mistake —
+that judgement is the reviewer's.
 
 **The live reference is `/design`** (`src/pages/design.tsx`). It resolves every token
 out of the DOM in all three themes at once and computes the WCAG contrast grid in the

--- a/e2e/contrast.spec.ts
+++ b/e2e/contrast.spec.ts
@@ -1,0 +1,244 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Contrast is a promise the token ramp makes, and until now nothing kept it.
+ *
+ * `--color-ink-3` had drifted to 4.17:1 on `--color-bg-hover` in the light
+ * theme and 4.08:1 on `--color-bg-active` in dim — both under the 4.5:1 AA
+ * floor that docs/frontend-conventions.md advertises — and the only way to
+ * notice was to open /design and read the grid. This suite makes that check
+ * automatic.
+ *
+ * It resolves tokens from the live stylesheet rather than from a table of
+ * hexes, so it measures what actually ships: a token changed in globals.css is
+ * a token re-measured here, with no second list to update.
+ */
+
+const THEMES = ['light', 'dim', 'dark'] as const;
+
+/** Every plane a piece of text can land on. */
+const SURFACES = [
+  '--color-bg',
+  '--color-bg-panel',
+  '--color-bg-sidebar',
+  '--color-bg-hover',
+  '--color-bg-active',
+] as const;
+
+/**
+ * The ink steps that carry real copy, plus the accent used for links. `ink-4`
+ * is deliberately absent: it is the decorative tier — separator marks,
+ * sparkline fills, icons echoing an adjacent label — and sits around 2.4-3.2:1
+ * by design. It is covered by the ramp-ordering check below instead.
+ */
+const BODY_FOREGROUNDS = [
+  '--color-ink',
+  '--color-ink-2',
+  '--color-ink-3',
+  '--color-accent-text',
+] as const;
+
+/** The full ramp, brightest to faintest, for the ordering invariant. */
+const INK_RAMP = [
+  '--color-ink',
+  '--color-ink-2',
+  '--color-ink-3',
+  '--color-ink-4',
+] as const;
+
+const AA = 4.5;
+
+type Rgb = [number, number, number];
+
+function parseRgb(value: string): Rgb {
+  const match = value.match(/-?[\d.]+/g);
+  if (!match || match.length < 3) {
+    throw new Error(`could not parse colour: ${value}`);
+  }
+  return [Number(match[0]), Number(match[1]), Number(match[2])];
+}
+
+/** WCAG 2.1 relative luminance. */
+function luminance([r, g, b]: Rgb): number {
+  const channel = (raw: number) => {
+    const c = raw / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Reads the given custom properties out of the browser, once per theme.
+ *
+ * Each theme gets its own `data-theme` subtree, which re-declares the whole
+ * palette for its descendants — the same trick /design uses to show all three
+ * themes side by side without touching the visitor's setting. Colours are read
+ * back off a probe's computed `color`, so the browser normalises whatever the
+ * token holds (hex, `color-mix`, another `var`) into plain `rgb()`.
+ */
+async function resolveTokens(
+  page: Page,
+  tokens: readonly string[],
+): Promise<Record<string, Record<string, Rgb>>> {
+  const raw = await page.evaluate(
+    ({ themes, names }) => {
+      const host = document.createElement('div');
+      host.style.cssText = 'position:absolute;left:-9999px;top:0';
+      document.body.appendChild(host);
+
+      const out: Record<string, Record<string, string>> = {};
+
+      for (const theme of themes) {
+        const scope = document.createElement('div');
+        scope.setAttribute('data-theme', theme);
+        host.appendChild(scope);
+
+        const probes = names.map((name) => {
+          const probe = document.createElement('span');
+          probe.style.color = `var(${name})`;
+          scope.appendChild(probe);
+          return probe;
+        });
+
+        // Read after the whole theme's probes are attached, so the batch costs
+        // one style recalculation rather than one per token.
+        out[theme] = Object.fromEntries(
+          names.map((name, i) => [name, getComputedStyle(probes[i]).color]),
+        );
+      }
+
+      host.remove();
+      return out;
+    },
+    { themes: [...THEMES], names: [...tokens] },
+  );
+
+  return Object.fromEntries(
+    Object.entries(raw).map(([theme, values]) => [
+      theme,
+      Object.fromEntries(
+        Object.entries(values).map(([name, value]) => [name, parseRgb(value)]),
+      ),
+    ]),
+  );
+}
+
+test.describe('Token contrast', () => {
+  test('every body-text ink clears WCAG AA on every surface, in every theme', async ({
+    page,
+  }) => {
+    await page.goto('/design');
+
+    const resolved = await resolveTokens(page, [
+      ...BODY_FOREGROUNDS,
+      ...SURFACES,
+    ]);
+
+    // Collect every failure before asserting. One bad pair usually means a
+    // whole row or column is off, and a report of all of them is far more
+    // useful than whichever happened to be measured first.
+    const failures: string[] = [];
+
+    for (const theme of THEMES) {
+      for (const fg of BODY_FOREGROUNDS) {
+        for (const bg of SURFACES) {
+          const ratio = contrastRatio(resolved[theme][fg], resolved[theme][bg]);
+          if (ratio < AA) {
+            failures.push(
+              `${theme}: ${fg} on ${bg} = ${ratio.toFixed(2)}:1 (needs ${AA})`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(
+      failures,
+      'a token in globals.css no longer meets the AA floor the ink ramp promises',
+    ).toEqual([]);
+  });
+
+  test('the ink ramp stays monotonic — each step is fainter than the last', async ({
+    page,
+  }) => {
+    await page.goto('/design');
+
+    const resolved = await resolveTokens(page, [...INK_RAMP, ...SURFACES]);
+    const inversions: string[] = [];
+
+    for (const theme of THEMES) {
+      for (const bg of SURFACES) {
+        const ratios = INK_RAMP.map((fg) =>
+          contrastRatio(resolved[theme][fg], resolved[theme][bg]),
+        );
+
+        for (let i = 1; i < ratios.length; i++) {
+          if (ratios[i] >= ratios[i - 1]) {
+            inversions.push(
+              `${theme} on ${bg}: ${INK_RAMP[i]} (${ratios[i].toFixed(2)}) is not fainter than ${INK_RAMP[i - 1]} (${ratios[i - 1].toFixed(2)})`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(
+      inversions,
+      'the ink ramp is meant to descend — two steps have crossed over',
+    ).toEqual([]);
+  });
+
+  test('text on an accent fill clears AA', async ({ page }) => {
+    await page.goto('/design');
+
+    const resolved = await resolveTokens(page, [
+      '--color-on-accent',
+      '--color-accent',
+    ]);
+
+    for (const theme of THEMES) {
+      const ratio = contrastRatio(
+        resolved[theme]['--color-on-accent'],
+        resolved[theme]['--color-accent'],
+      );
+
+      expect(
+        ratio,
+        `${theme}: --color-on-accent on --color-accent = ${ratio.toFixed(2)}:1`,
+      ).toBeGreaterThanOrEqual(AA);
+    }
+  });
+
+  test('hover and active surfaces are actually distinguishable from the page', async ({
+    page,
+  }) => {
+    await page.goto('/design');
+
+    const resolved = await resolveTokens(page, [...SURFACES]);
+
+    // There is no WCAG floor for "this row is highlighted", but a state that
+    // renders at 1.00 is no state at all. 1.05 is roughly where the shift stops
+    // being visible on a mediocre panel.
+    for (const theme of THEMES) {
+      for (const surface of [
+        '--color-bg-hover',
+        '--color-bg-active',
+      ] as const) {
+        const ratio = contrastRatio(
+          resolved[theme][surface],
+          resolved[theme]['--color-bg'],
+        );
+
+        expect(
+          ratio,
+          `${theme}: ${surface} is indistinguishable from --color-bg`,
+        ).toBeGreaterThan(1.05);
+      }
+    }
+  });
+});

--- a/e2e/design-system.spec.ts
+++ b/e2e/design-system.spec.ts
@@ -165,6 +165,34 @@ test.describe('Design system page', () => {
     await expectScrolledToComponents(page);
   });
 
+  test('the tab strip stays pinned to the top while scrolling', async ({
+    page,
+  }) => {
+    // Regression: the strip was wrapped in a plain div carrying its responsive
+    // hiding, which made that div the sticky bar's containing block. A sticky
+    // element cannot leave its parent's box, and the wrapper was only as tall
+    // as the tabs, so the bar scrolled away on the first flick — on phones,
+    // where it is the *only* navigation the page has.
+    await page.setViewportSize({ width: 390, height: 780 });
+    await page.goto('/design');
+    await page.waitForLoadState('networkidle');
+
+    const tablist = page.getByRole('tablist');
+    await expect(tablist).toBeVisible();
+
+    const main = page.locator('main');
+    await main.evaluate((el) => el.scrollTo(0, 1500));
+
+    // <main> carries `scroll-smooth`, so the scroll animates. Wait for it to
+    // land before measuring — polling the tab bar's position directly would
+    // sample it at offset 0 on the first tick and pass without ever scrolling.
+    await expect
+      .poll(() => main.evaluate((el) => el.scrollTop), { timeout: 5_000 })
+      .toBeGreaterThan(1_000);
+
+    expect((await tablist.boundingBox())?.y).toBe(0);
+  });
+
   test('component demos render the real primitives', async ({ page }) => {
     await page.goto('/design');
     await page.waitForLoadState('networkidle');

--- a/src/components/Blog/Post/TableOfContents.tsx
+++ b/src/components/Blog/Post/TableOfContents.tsx
@@ -56,10 +56,12 @@ export const TableOfContents = ({ headings, activeSlug }: Props) => {
                   // the whole declaration and nothing transitioned
                   'block py-1 no-underline transition-[color,transform] duration-150 leading-[1.4]',
                   heading.level === 3 ? 'text-[12px]' : 'text-[13px]',
-                  'hover:text-(--color-ink-3)',
+                  'hover:text-(--color-ink-2)',
                   isActive
                     ? 'font-bold text-(--color-ink-2) transform translate-x-0.5'
-                    : 'font-normal text-(--color-ink-4)',
+                    : // These are navigation links, so they sit on ink-3.
+                      // ink-4 is the decorative tier and reads at ~2.5:1.
+                      'font-normal text-(--color-ink-3)',
                 )}
               >
                 {cleanHeadingContent(heading.content)}

--- a/src/components/Blog/PostRow.tsx
+++ b/src/components/Blog/PostRow.tsx
@@ -65,7 +65,7 @@ export function PostRow({ item }: PostRowProps) {
             )
           )}
         </div>
-        <div className="text-[12px] text-(--color-ink-4) mt-[2px]">
+        <div className="text-[12px] text-(--color-ink-3) mt-[2px]">
           {formatPostDate(date)} · {readingTime}
         </div>
       </div>

--- a/src/components/about/CareerView.tsx
+++ b/src/components/about/CareerView.tsx
@@ -313,8 +313,19 @@ export function CareerView() {
       </div>
       {/* end stickyRef */}
 
-      {/* Stacked list of all career items — newest first */}
-      <div className="flex flex-col gap-1 overflow-hidden" role="list">
+      {/* Stacked list of all career items — newest first.
+          The rail is one continuous hairline behind the dots, so this reads as
+          a timeline rather than as a stack of rows each wearing its own bar.
+          It sits at the dots' centre line (px-3 padding + half of the 8px dot)
+          and the opaque dots cover it where they land. */}
+      <div className="relative flex flex-col gap-1 overflow-hidden" role="list">
+        {/* Above the row fills (z-1), below the dots (z-2). Behind them the
+            selected row's background would paint over the rail and break it
+            into two pieces exactly where the eye is already looking. */}
+        <span
+          aria-hidden="true"
+          className="absolute left-4 top-4 bottom-4 w-px bg-(--color-border) z-[1]"
+        />
         {LIST_ITEMS.map(({ item, chartIndex }) => {
           const isSelected = selected === chartIndex;
           const isExpanded = expanded === chartIndex;
@@ -331,24 +342,31 @@ export function CareerView() {
                   listItemRefs.current[chartIndex] = el;
                 }}
                 onClick={() => selectAndScrollChart(chartIndex)}
-                className="w-full text-left rounded-lg px-3 py-2.5 transition-colors cursor-pointer"
+                className="relative w-full text-left rounded-lg px-3 py-2.5 transition-colors cursor-pointer"
                 style={{
+                  // Selection is carried by the fill and by the halo on the
+                  // dot below. It used to also get a 3px coloured left border,
+                  // which fought the rounded corner and repeated a colour the
+                  // dot was already showing.
                   background: isSelected
                     ? 'var(--color-bg-hover)'
                     : 'transparent',
-                  borderLeft: isSelected
-                    ? `3px solid ${barColor}`
-                    : '3px solid transparent',
                 }}
               >
                 <div className="flex items-center gap-2.5 min-w-0">
-                  {/* Color dot */}
+                  {/* The dot sits on the rail and is the only thing carrying
+                      this entry's colour. Selected, it gains a halo in that
+                      same colour — the marker grows rather than a second
+                      element appearing beside it. */}
                   <span
-                    className="shrink-0 rounded-full -translate-y-0.5"
+                    className="relative z-[2] shrink-0 rounded-full -translate-y-0.5 transition-shadow duration-150"
                     style={{
                       width: 8,
                       height: 8,
                       background: barColor,
+                      boxShadow: isSelected
+                        ? `0 0 0 3.5px color-mix(in srgb, ${barColor} 28%, transparent)`
+                        : 'none',
                     }}
                   />
 
@@ -388,7 +406,7 @@ export function CareerView() {
                       size={14}
                       className="shrink-0 transition-transform duration-200"
                       style={{
-                        color: 'var(--color-ink-4)',
+                        color: 'var(--color-ink-3)',
                         transform: isExpanded
                           ? 'rotate(180deg)'
                           : 'rotate(0deg)',
@@ -405,7 +423,10 @@ export function CareerView() {
                 </div>
               </button>
 
-              {/* Expanded details — inline with continued left border */}
+              {/* Expanded details. No border of its own: the rail already runs
+                  behind this, so the stub was a second vertical line drawn on
+                  top of the first. Indented to 30px — px-3 + the 8px dot + the
+                  2.5 gap — so the prose starts under the title, not the dot. */}
               <AnimatePresence>
                 {isExpanded && item.details && (
                   <motion.div
@@ -415,12 +436,7 @@ export function CareerView() {
                     transition={{ duration: 0.2, ease: 'easeInOut' }}
                     style={{ overflow: 'hidden' }}
                   >
-                    <div
-                      className="ml-3 pl-5 mr-3 pb-3"
-                      style={{
-                        borderLeft: `2px solid ${barColor}`,
-                      }}
-                    >
+                    <div className="pl-[30px] pr-3 pb-3">
                       <div className="text-[14px] leading-[1.75] text-(--color-ink-3)">
                         {item.details}
                       </div>

--- a/src/components/about/ProjectsView.tsx
+++ b/src/components/about/ProjectsView.tsx
@@ -57,7 +57,7 @@ export function ProjectsView() {
                       href={project.repo}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-[12px] text-(--color-ink-4) no-underline font-medium hover:text-(--color-ink)"
+                      className="inline-flex items-center gap-1 text-[12px] text-(--color-ink-3) no-underline font-medium hover:text-(--color-ink)"
                     >
                       <GithubIcon size={12} aria-hidden="true" />
                       Source
@@ -98,7 +98,7 @@ export function ProjectsView() {
               href={repo.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-[12px] text-(--color-ink-4) no-underline font-medium hover:text-(--color-accent-text) shrink-0"
+              className="inline-flex items-center gap-1 text-[12px] text-(--color-ink-3) no-underline font-medium hover:text-(--color-accent-text) shrink-0"
               title="View on GitHub"
             >
               <GithubIcon size={14} aria-hidden="true" />

--- a/src/components/common/SectionLabel/index.tsx
+++ b/src/components/common/SectionLabel/index.tsx
@@ -18,7 +18,10 @@ export function SectionLabel({
   return (
     <As
       className={cn(
-        'text-[11px] font-semibold tracking-[0.08em] uppercase text-(--color-ink-4)',
+        // ink-3 rather than ink-4. These are group headings — sidebar nav
+        // sections, widget titles, command-palette result groups — and at 11px
+        // they count as small text, so they owe the reader the full 4.5:1.
+        'text-[11px] font-semibold tracking-[0.08em] uppercase text-(--color-ink-3)',
         className,
       )}
       {...rest}

--- a/src/components/common/SegmentedControl/index.tsx
+++ b/src/components/common/SegmentedControl/index.tsx
@@ -32,6 +32,7 @@ export function SegmentedControl<T extends string>({
       {options.map((opt) => (
         <button
           key={opt.value}
+          type="button"
           onClick={() => onChange(opt.value)}
           title={opt.title ?? opt.label}
           aria-label={opt.label ? `Switch to ${opt.label}` : opt.title}
@@ -40,7 +41,10 @@ export function SegmentedControl<T extends string>({
             'flex-1 flex items-center justify-center gap-1 px-[9px] py-[5px] text-[11px] font-medium cursor-pointer border-none font-[inherit] rounded-[7px] transition-[background,color,box-shadow] duration-[130ms] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--color-accent)',
             value === opt.value
               ? 'bg-(--color-bg-panel) text-(--color-accent-text) shadow-(--shadow-sm)'
-              : 'bg-transparent text-(--color-ink-4)',
+              : // ink-3, not ink-4: the unselected segments are the ones you
+                // have to read to know what you would be switching to, and
+                // ink-4 is the decorative tier at roughly 2.5:1.
+                'bg-transparent text-(--color-ink-3)',
           )}
         >
           {opt.icon}

--- a/src/components/design-system/PageNav.tsx
+++ b/src/components/design-system/PageNav.tsx
@@ -52,10 +52,11 @@ export function PageNav({ outline, activeId, onNavigate }: Props) {
             'block py-1 no-underline leading-[1.4]',
             'transition-[color,transform] duration-150',
             depth === 1 ? 'text-[12px]' : 'text-[13px]',
-            'hover:text-(--color-ink-3)',
+            'hover:text-(--color-ink-2)',
             isActive
               ? 'font-bold text-(--color-ink-2) translate-x-0.5'
-              : 'font-normal text-(--color-ink-4)',
+              : // Navigation links, so ink-3 — same rule as the blog's ToC.
+                'font-normal text-(--color-ink-3)',
           )}
         >
           {label}

--- a/src/components/design-system/Scaffold.tsx
+++ b/src/components/design-system/Scaffold.tsx
@@ -188,7 +188,7 @@ export function PropTable({ rows }: { rows: PropRow[] }) {
               <th
                 key={h}
                 scope="col"
-                className="py-2 pr-4 text-[11px] font-semibold tracking-[0.08em] uppercase text-(--color-ink-4) whitespace-nowrap"
+                className="py-2 pr-4 text-[11px] font-semibold tracking-[0.08em] uppercase text-(--color-ink-3) whitespace-nowrap"
               >
                 {h}
               </th>
@@ -207,7 +207,7 @@ export function PropTable({ rows }: { rows: PropRow[] }) {
               <td className="py-2 pr-4 font-mono text-[11px] text-(--color-accent-text) min-w-[140px]">
                 {row.type}
               </td>
-              <td className="py-2 pr-4 font-mono text-[11px] text-(--color-ink-4) whitespace-nowrap">
+              <td className="py-2 pr-4 font-mono text-[11px] text-(--color-ink-3) whitespace-nowrap">
                 {row.defaultValue ?? '—'}
               </td>
               <td className="py-2 text-[12px] leading-[1.5] text-(--color-ink-3) min-w-[200px]">

--- a/src/components/design-system/sections/ColorSection.tsx
+++ b/src/components/design-system/sections/ColorSection.tsx
@@ -34,7 +34,7 @@ function SwatchCell({
           style={{ background: value ?? 'transparent' }}
         />
       </div>
-      <span className="font-mono text-[10px] leading-none text-(--color-ink-4) tabular-nums truncate">
+      <span className="font-mono text-[10px] leading-none text-(--color-ink-3) tabular-nums truncate">
         {/* The column headers are desktop-only, so each swatch names its own
             theme once the grid stacks. */}
         <span className="md:hidden uppercase tracking-[0.06em] mr-[6px]">
@@ -57,7 +57,7 @@ function TokenRow({
     <div className="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_repeat(3,minmax(72px,110px))] gap-x-4 gap-y-2 items-start py-3 border-b border-(--color-border) last:border-0">
       <div className="min-w-0">
         <CopyChip value={spec.token} className="-ml-[6px]" />
-        <Text variant="caption" color="ink-4" className="px-[6px] mt-[1px]">
+        <Text variant="caption" color="ink-3" className="px-[6px] mt-[1px]">
           {spec.usage}
         </Text>
       </div>
@@ -101,7 +101,7 @@ export function ColorSection() {
               {THEMES.map((theme) => (
                 <span
                   key={theme}
-                  className="text-[10px] font-semibold tracking-[0.08em] uppercase text-(--color-ink-4)"
+                  className="text-[10px] font-semibold tracking-[0.08em] uppercase text-(--color-ink-3)"
                 >
                   {theme}
                 </span>
@@ -135,7 +135,7 @@ export function ColorSection() {
               <code className="font-mono text-[12px] text-(--color-accent-text)">
                 {cls}
               </code>
-              <span className="text-[11px] text-(--color-ink-4) shrink-0">
+              <span className="text-[11px] text-(--color-ink-3) shrink-0">
                 {label}
               </span>
             </div>

--- a/src/components/design-system/sections/ComponentsSection.tsx
+++ b/src/components/design-system/sections/ComponentsSection.tsx
@@ -47,7 +47,7 @@ function Spec({
           <h3 className="text-[17px] font-bold font-serif text-(--color-ink) m-0">
             {name}
           </h3>
-          <code className="font-mono text-[11px] text-(--color-ink-4)">
+          <code className="font-mono text-[11px] text-(--color-ink-3)">
             {file}
           </code>
         </div>
@@ -77,7 +77,7 @@ function Spec({
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)',
                   (propRows ? tab : 'code') === t
                     ? 'bg-(--color-bg-active) text-(--color-accent-text)'
-                    : 'text-(--color-ink-4) hover:text-(--color-ink-2)',
+                    : 'text-(--color-ink-3) hover:text-(--color-ink-2)',
                 )}
               >
                 {t === 'props' ? 'Props' : 'Usage'}

--- a/src/components/design-system/sections/ContrastSection.tsx
+++ b/src/components/design-system/sections/ContrastSection.tsx
@@ -70,7 +70,7 @@ export function ContrastSection() {
                   <th
                     key={bg}
                     scope="col"
-                    className="px-2 pb-2 font-mono text-[10px] font-medium text-(--color-ink-4) text-center whitespace-nowrap"
+                    className="px-2 pb-2 font-mono text-[10px] font-medium text-(--color-ink-3) text-center whitespace-nowrap"
                   >
                     {short(bg)}
                   </th>
@@ -82,7 +82,7 @@ export function ContrastSection() {
                 <tr key={fg}>
                   <th
                     scope="row"
-                    className="pr-3 py-1 font-mono text-[10px] font-medium text-(--color-ink-4) text-right whitespace-nowrap"
+                    className="pr-3 py-1 font-mono text-[10px] font-medium text-(--color-ink-3) text-right whitespace-nowrap"
                   >
                     {short(fg)}
                   </th>
@@ -126,11 +126,17 @@ export function ContrastSection() {
           </table>
         </div>
 
-        <Text variant="caption" color="ink-4" className="mt-3 max-w-[68ch]">
+        {/* On ink-3, not ink-4 — a footnote saying "don't put readable text on
+            ink-4" has to take its own advice. */}
+        <Text variant="caption" color="ink-3" className="mt-3 max-w-[68ch]">
           <code className="font-mono">ink-4</code> is expected to fail here — it
-          is a decorative tier, used for placeholders and for labels that repeat
-          information already carried by an adjacent element. Nothing that has
-          to be read on its own should use it.
+          is a decorative tier, for separator marks, sparkline fills and icons
+          that repeat information an adjacent element already carries. Nothing
+          that has to be read on its own should use it. Every other row is held
+          above the AA line by{' '}
+          <code className="font-mono">e2e/contrast.spec.ts</code>, which
+          resolves these same tokens in a browser and fails the build if one
+          drifts under.
         </Text>
       </Block>
     </Section>

--- a/src/components/design-system/sections/SurfaceSection.tsx
+++ b/src/components/design-system/sections/SurfaceSection.tsx
@@ -22,7 +22,7 @@ function ShadowSample({ token, usage }: { token: string; usage: string }) {
       />
       <div>
         <CopyChip value={token} className="-ml-[6px]" />
-        <Text variant="caption" color="ink-4" className="px-[6px]">
+        <Text variant="caption" color="ink-3" className="px-[6px]">
           {usage}
         </Text>
       </div>
@@ -94,7 +94,7 @@ export function SurfaceSection() {
                 <code className="block font-mono text-[11px] text-(--color-ink-2)">
                   {r.className}
                 </code>
-                <span className="text-[10px] text-(--color-ink-4) tabular-nums">
+                <span className="text-[10px] text-(--color-ink-3) tabular-nums">
                   {r.value}
                 </span>
               </div>
@@ -118,7 +118,7 @@ export function SurfaceSection() {
               style={{ borderColor: `var(${token})` }}
             >
               <CopyChip value={token} className="-ml-[6px]" />
-              <Text variant="caption" color="ink-4" className="px-[6px]">
+              <Text variant="caption" color="ink-3" className="px-[6px]">
                 {label}
               </Text>
             </div>
@@ -178,7 +178,7 @@ export function SurfaceSection() {
                 <code className="block font-mono text-[11px] text-(--color-ink-2)">
                   {k.name}
                 </code>
-                <span className="text-[10px] text-(--color-ink-4)">
+                <span className="text-[10px] text-(--color-ink-3)">
                   {k.usage}
                 </span>
               </div>
@@ -186,7 +186,7 @@ export function SurfaceSection() {
           ))}
         </div>
 
-        <Text variant="caption" color="ink-4" className="mt-4 max-w-[68ch]">
+        <Text variant="caption" color="ink-3" className="mt-4 max-w-[68ch]">
           All of it collapses to 0.01ms under{' '}
           <code className="font-mono">prefers-reduced-motion</code>, which is
           handled once in globals.css rather than per component.

--- a/src/components/design-system/sections/TypographySection.tsx
+++ b/src/components/design-system/sections/TypographySection.tsx
@@ -97,7 +97,7 @@ export function TypographySection() {
                 <Text variant="caption-sm" as="span">
                   {item.spec}
                 </Text>
-                <Text variant="caption-sm" color="ink-4" as="span">
+                <Text variant="caption-sm" color="ink-3" as="span">
                   {item.note}
                 </Text>
               </div>

--- a/src/components/layout/SectionTabs.tsx
+++ b/src/components/layout/SectionTabs.tsx
@@ -12,15 +12,28 @@ interface SectionTabsProps {
   tabs: Tab[];
   activeTab: string;
   onTabChange: (id: string) => void;
+  /**
+   * Extra classes for the sticky root — responsive visibility belongs here
+   * rather than on a wrapper. A sticky element cannot travel outside its
+   * parent's box, so wrapping this in a plain `<div>` collapses that box to the
+   * height of the tabs and the bar scrolls away on the first flick.
+   */
+  className?: string;
 }
 
 export function SectionTabs({
   tabs,
   activeTab,
   onTabChange,
+  className,
 }: SectionTabsProps) {
   return (
-    <div className="bg-(--color-bg) shrink-0 sticky top-0 z-10 transition-[background-color] duration-[220ms] ease-out">
+    <div
+      className={cn(
+        'bg-(--color-bg) shrink-0 sticky top-0 z-10 transition-[background-color] duration-[220ms] ease-out',
+        className,
+      )}
+    >
       <div
         role="tablist"
         className="max-w-[880px] mx-auto px-5 md:px-13 overflow-y-hidden overflow-x-auto flex items-center gap-[2px]"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -43,11 +43,11 @@ export function Sidebar() {
         {/* CMD trigger — hidden on icon-strip sidebar */}
         <button
           onClick={() => setIsOpen(true)}
-          className="hidden lg:flex mt-[10px] w-full items-center gap-[6px] px-[10px] py-[6px] rounded-lg border border-(--color-border) bg-(--color-bg) text-(--color-ink-4) text-[13px] cursor-pointer font-[inherit] text-left transition-[border-color,color] duration-[150ms] hover:border-(--color-accent-l) hover:text-(--color-ink-3)"
+          className="hidden lg:flex mt-[10px] w-full items-center gap-[6px] px-[10px] py-[6px] rounded-lg border border-(--color-border) bg-(--color-bg) text-(--color-ink-3) text-[13px] cursor-pointer font-[inherit] text-left transition-[border-color,color] duration-[150ms] hover:border-(--color-accent-l) hover:text-(--color-ink-2)"
         >
           <SearchIcon size={13} aria-hidden="true" />
           <span className="flex-1">Quick actions…</span>
-          <span className="ml-auto text-[10px] border border-(--color-border) rounded-[4px] px-[5px] py-[1px] text-(--color-ink-4)">
+          <span className="ml-auto text-[10px] border border-(--color-border) rounded-[4px] px-[5px] py-[1px] text-(--color-ink-3)">
             ⌘K
           </span>
         </button>
@@ -57,7 +57,7 @@ export function Sidebar() {
           onClick={() => setIsOpen(true)}
           title="Quick actions (⌘K)"
           aria-label="Quick actions"
-          className="flex lg:hidden mt-[10px] w-full items-center justify-center p-[6px] rounded-lg border border-(--color-border) bg-(--color-bg) text-(--color-ink-4) cursor-pointer font-[inherit] transition-[background,border-color] duration-[130ms] hover:bg-(--color-bg-hover) hover:border-(--color-accent-l)"
+          className="flex lg:hidden mt-[10px] w-full items-center justify-center p-[6px] rounded-lg border border-(--color-border) bg-(--color-bg) text-(--color-ink-3) cursor-pointer font-[inherit] transition-[background,border-color] duration-[130ms] hover:bg-(--color-bg-hover) hover:border-(--color-accent-l)"
         >
           <SearchIcon size={14} aria-hidden="true" />
         </button>

--- a/src/components/tools/Claymorphism/index.tsx
+++ b/src/components/tools/Claymorphism/index.tsx
@@ -18,6 +18,28 @@ const hexToRgb = (hex: `#${string}`) => {
   return { red, green, blue };
 };
 
+/**
+ * The inverse, and it has to pad.
+ *
+ * `<input type="color">` accepts `#rrggbb` and nothing else — it rejects the
+ * value outright and falls back to black otherwise. Bare `toString(16)` drops
+ * the leading zero on any channel under 16, so the default all-zero state
+ * emitted `#000`, and a colour like rgb(10, 200, 5) emitted `#ac85`: four
+ * characters, silently wrong, and not the colour anyone picked.
+ */
+const rgbToHex = ({
+  red,
+  green,
+  blue,
+}: {
+  red: number;
+  green: number;
+  blue: number;
+}) =>
+  `#${[red, green, blue]
+    .map((channel) => channel.toString(16).padStart(2, '0'))
+    .join('')}`;
+
 export const ClaymorphismTools = () => {
   const [lightAngle, setLightAngle] = useState((1 * Math.PI) / 3);
   const [elevation, setElevation] = useState(0.5);
@@ -78,11 +100,7 @@ export const ClaymorphismTools = () => {
             id="shadowColor"
             name="shadowColor"
             type="color"
-            value={`#${baseShadowColors.red.toString(
-              16,
-            )}${baseShadowColors.green.toString(
-              16,
-            )}${baseShadowColors.blue.toString(16)}`}
+            value={rgbToHex(baseShadowColors)}
             onChange={(e) =>
               setBaseShadowColors(hexToRgb(e.target.value as `#${string}`))
             }

--- a/src/pages/design.tsx
+++ b/src/pages/design.tsx
@@ -80,14 +80,16 @@ export default function DesignSystemPage() {
       />
 
       <div className="flex flex-col flex-1">
-        {/* Below the rail's breakpoint the strip is the only navigation. */}
-        <div className="min-[1200px]:hidden">
-          <SectionTabs
-            tabs={TABS}
-            activeTab={activeSection}
-            onTabChange={scrollTo}
-          />
-        </div>
+        {/* Below the rail's breakpoint the strip is the only navigation. The
+            hiding goes on SectionTabs itself: a wrapper would become the sticky
+            bar's containing block and pin it to its own height, which is to say
+            not pin it at all. */}
+        <SectionTabs
+          tabs={TABS}
+          activeTab={activeSection}
+          onTabChange={scrollTo}
+          className="min-[1200px]:hidden"
+        />
 
         {/* 880px column + 224px rail = 1104px, the same arrangement the blog
             uses. Under 1200px the rail drops out and the column re-centres. */}

--- a/src/pages/design.tsx
+++ b/src/pages/design.tsx
@@ -116,7 +116,7 @@ export default function DesignSystemPage() {
                   key={stat.label}
                   className="rounded-lg border border-(--color-border) bg-(--color-bg-panel) px-3 py-[10px]"
                 >
-                  <dt className="text-[11px] font-semibold tracking-[0.08em] uppercase text-(--color-ink-4)">
+                  <dt className="text-[11px] font-semibold tracking-[0.08em] uppercase text-(--color-ink-3)">
                     {stat.label}
                   </dt>
                   <dd className="text-2xl font-bold font-serif text-(--color-ink) tabular-nums leading-tight">
@@ -126,7 +126,7 @@ export default function DesignSystemPage() {
               ))}
             </dl>
 
-            <Text variant="caption" color="ink-4" className="mb-2">
+            <Text variant="caption" color="ink-3" className="mb-2">
               Tokens live in{' '}
               <code className="font-mono">src/styles/globals.css</code>;
               primitives in{' '}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -110,7 +110,9 @@
   --color-border-hi: #ccc8be;
   --color-ink: #24242a;
   --color-ink-2: #38383c;
-  --color-ink-3: #6b6b72;
+  /* Darkened from #6b6b72: on --color-bg-hover the old value measured 4.17:1,
+     under the 4.5 AA floor this ramp claims. See the note above ink-4. */
+  --color-ink-3: #616168;
   --color-ink-4: #908f96;
   --color-accent: #2c6464;
   --color-accent-2: #1a4040;
@@ -163,14 +165,18 @@
   --color-border-hi: #3a3d48;
   --color-ink: #d8d6d0;
   --color-ink-2: #b8b5ae;
-  --color-ink-3: #918f98;
+  /* Lightened from #918f98: 4.13:1 on hover and 4.08:1 on active, both under AA. */
+  --color-ink-3: #9f9da6;
   --color-ink-4: #686670;
   --color-accent: #4a9696;
   --color-accent-2: #6ab8b8;
   --color-accent-l: #1e4040;
   --color-accent-xl: #162e2e;
   --color-accent-text: #6ab8b8;
-  --color-on-accent: #ffffff;
+  /* Ink, not white. The dark themes' accent is a mid teal, so white sits at
+     3.45:1 on it — and the primary Button lightens the fill on hover, which
+     drops it to 2.89:1. Dark ink reverses both: 5.56:1 at rest, 6.63:1 hovered. */
+  --color-on-accent: #0f0f11;
 
   --grid-primary: rgba(74, 150, 150, 0.07);
   --grid-faint: rgba(74, 150, 150, 0.028);
@@ -205,7 +211,7 @@
   /* ── Chrome ── */
   --scroll-gutter: hsl(225deg 13% 15%);
   --color-selection-bg: var(--color-accent);
-  --color-selection-text: #1a1b20;
+  --color-selection-text: var(--color-on-accent);
 }
 
 [data-theme='dark'] {
@@ -218,14 +224,17 @@
   --color-border-hi: #2e2e34;
   --color-ink: #d8d6d0;
   --color-ink-2: #b0ada6;
-  --color-ink-3: #8a8890;
+  /* Nudged from #8a8890, which passed at only 4.58:1 on active — enough
+     headroom to match the other two themes' ~4.8 floor. */
+  --color-ink-3: #8e8c94;
   --color-ink-4: #5c5a64;
   --color-accent: #4a9696;
   --color-accent-2: #7ac4c4;
   --color-accent-l: #1a3636;
   --color-accent-xl: #111e1e;
   --color-accent-text: #7ac4c4;
-  --color-on-accent: #ffffff;
+  /* See the dim theme's note — same accent, same reason. */
+  --color-on-accent: #0f0f11;
 
   --grid-primary: rgba(74, 150, 150, 0.08);
   --grid-faint: rgba(74, 150, 150, 0.03);
@@ -260,7 +269,7 @@
   /* ── Chrome ── */
   --scroll-gutter: hsl(240deg 10% 9%);
   --color-selection-bg: var(--color-accent);
-  --color-selection-text: #0f0f11;
+  --color-selection-text: var(--color-on-accent);
 }
 
 /* ═══════════════════════════════════════


### PR DESCRIPTION
Follow-up to #128. Starts with the `ink-3` on `bg-hover` finding left open there, and follows it where it led.

## The contrast bug, and the two it was hiding

`docs/frontend-conventions.md` advertised `--color-ink-3` as "≥4.5:1, WCAG AA". On the hover and active surfaces it was not:

| theme | on `bg-hover` | on `bg-active` |
|---|---|---|
| light | **4.17** | 4.50 |
| dim | **4.13** | **4.08** |
| dark | 4.75 | 4.58 |

Retuned in all three themes to a ~4.8:1 floor against every surface — a hair over the line is how it drifted under in the first place, so there is now enough headroom that breaking it takes a deliberate act.

Then I added `e2e/contrast.spec.ts`, which resolves the tokens out of a real browser (one `data-theme` subtree per theme, colours read off a probe's computed `color`) and fails on any pair under AA. **It immediately found a second bug I had not been looking for:**

`--color-on-accent` was `#ffffff` on the dark themes' mid-teal `--color-accent` — **3.45:1**. That pair is the primary `Button`, which lightens its fill on hover, taking the label to **2.89:1**. Dark ink reverses both: 5.56:1 at rest, 6.63:1 hovered. The *selection* tokens in dim and dark had already independently arrived at dark-on-accent, so they now share the token instead of open-coding it.

## The ink-4 misuse

`--color-ink-4` is the decorative tier — 2.4–3.2:1, below AA everywhere, on purpose. It had drifted into carrying text people actually have to read:

- `SegmentedControl` — the *unselected* labels, i.e. the ones you read to know what you'd be switching to (theme switcher, mobile nav, homepage widgets)
- `TableOfContents` and the `/design` page rail — navigation links
- `SectionLabel` — sidebar nav groups, widget titles, command-palette result headings; 11px still counts as small text
- the sidebar's ⌘K trigger, project links, post meta lines
- and, with some irony, the `/design` footnote that says not to put readable text on `ink-4`

Those move to `ink-3`. Genuinely ornamental uses stay — separator dots, sparkline fills, the empty-state numeral, the copy chip's underline. The rule is now written down, and the test guards the part a machine can judge.

## Mobile tab strip

Reported mid-review, and a real one. On `/design` the strip was wrapped in a plain `div` carrying its responsive hiding — which quietly made that wrapper the sticky bar's containing block. A sticky element can't travel outside its parent's box, and the wrapper was only as tall as the tabs, so the bar came unstuck on the first flick. Below 1200px the rail is gone and that strip is the page's *only* navigation. `/about` was unaffected — it passes `SectionTabs` as a direct child of the tall flex column, which is what this now does too.

Worth flagging how the regression test went, because the first version was worthless: polling the bar's own offset **passed against the broken markup**. The `main` element carries `scroll-smooth`, so the first sample landed before the animation started and read offset 0. It now waits for the scroll to settle, then measures. Verified failing on the old markup and passing on the new — otherwise there's no point keeping it.

## Career timeline

The selected entry wore a 3px coloured bar down the left of a rounded rectangle — the treatment `Panel` lost in #128, with the same problems: it fought the rounded corner, and it repeated a colour the dot beside it already showed.

The deeper issue was that there was no timeline. Each row drew its own short bar, and a second stub appeared under a row only while expanded, so the vertical line existed in fragments that never joined. Replaced with one continuous hairline behind the dots, at their centre line — the dots now sit on a rail instead of implying one. Selection is the row fill plus a halo on that entry's own dot, and expanded details indent to the title rather than hanging off a stub.

The rail paints above the row fills and below the dots. Behind them, the selected row's background covered the rail and broke it in two at exactly the point the eye is drawn to.

## Claymorphism colour input

Found by walking every page with the browser console attached. A colour input accepts `#rrggbb` and nothing else, but the value was assembled with a bare `toString(16)` per channel, so any channel under 16 lost its leading zero. The default all-zero state produced `#000` — rejected outright, with a console warning — and rgb(10, 200, 5) produced `#ac85`: four characters, silently not the colour anyone picked. Now padded.

## Also

`SegmentedControl` was missing `type="button"`, so it would have submitted any form it were nested in.

## ⚠️ One thing you need to do locally

**The 18 visual snapshots are now stale and I can't regenerate them.** They're `-chromium-darwin.png`, generated on your Mac; CI skips them (`--grep-invert "Visual"`), so nothing here goes red, but they will fail on your machine. Every one contains text this PR recolours, and the `/about` pair also changes shape from the timeline work. Tolerance is `maxDiffPixelRatio: 0.01`.

```
pnpm test:e2e --grep "Visual" --update-snapshots
```

Worth eyeballing rather than accepting blind — it's the clearest view of how far `SectionLabel` moved.

## Verification

- `pnpm lint` and `tsc --noEmit` clean
- Full e2e suite green locally (42 tests, visual excluded); CI green on every commit
- Both new tests confirmed to fail without their fix
- Screenshotted `/`, `/blog`, `/design` and the career timeline in all three themes, desktop and 390px
- Swept every page at 390px for horizontal overflow (none), checked all internal links resolve, and collected console errors across 10 pages

## Judgement calls left to you

- **`SectionLabel` moving to `ink-3` is the most visible change here** — those labels appear on nearly every page and are now a step less muted. Correct by the rule, but it is a look, so it's yours to veto.
- Command-palette **placeholder** text is still `ink-4`. It technically fails, but a placeholder at `ink-3` starts reading like a filled-in value, so I left it.
- Border tokens sit at 1.2–1.5:1 against the page. Fine for decorative hairlines; if any are meant to convey a boundary on their own they'd need 3:1. I didn't change them.
- `/resume` logs three.js deprecation warnings (`THREE.Clock`, `PCFSoftShadowMap`). Real but unrelated, so left alone.

## One review comment declined

CodeRabbit flagged light `ink-3` as 4.49:1 and predicted the new test would fail. It's 4.84:1 — verified by hand and by reading the value back out of the shipped stylesheet in a browser — and CI e2e was green, which is the check that would have caught 4.49. CodeRabbit withdrew the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLS8pQRUGyEGQi1kTFAcbb