### PR TITLE
Sit the resume panels against the things they open from

### DIFF
--- a/src/components/resume/CozyRoom/Room.tsx
+++ b/src/components/resume/CozyRoom/Room.tsx
@@ -175,22 +175,28 @@ function ScenePanel({
             onPointerMove={(event) => event.stopPropagation()}
             onWheel={(event) => event.stopPropagation()}
           >
-            <div className="flex items-center justify-between gap-2 px-5 pt-4 pb-2">
-              <Heading level={3} as="h2" id={headingId}>
-                {SECTION_TITLES[section]}
-              </Heading>
-              <button
-                ref={closeRef}
-                type="button"
-                aria-label={`Close ${SECTION_TITLES[section]}`}
-                onClick={onClose}
-                className="cursor-pointer rounded-full p-1.5 text-(--color-ink-3) transition-[color,background-color,transform] duration-150 hover:bg-(--color-bg-hover) hover:text-(--color-ink) active:scale-90"
-              >
-                <XIcon size={18} aria-hidden="true" />
-              </button>
-            </div>
-            <ScrollArea className="max-h-[380px] px-5 pt-1 pb-5">
-              <ResumeSectionContent section={section} writings={writings} />
+            {/* The title bar scrolls with the content rather than sitting
+                beside it, so a wheel anywhere over the card reaches the one
+                scroll surface — and the section keeps naming itself, and
+                stays closeable, however far down the reader is */}
+            <ScrollArea className="max-h-[430px]">
+              <div className="sticky top-0 z-10 flex items-center justify-between gap-2 bg-(--color-bg-panel) px-5 pt-4 pb-3">
+                <Heading level={3} as="h2" id={headingId}>
+                  {SECTION_TITLES[section]}
+                </Heading>
+                <button
+                  ref={closeRef}
+                  type="button"
+                  aria-label={`Close ${SECTION_TITLES[section]}`}
+                  onClick={onClose}
+                  className="cursor-pointer rounded-full p-1.5 text-(--color-ink-3) transition-[color,background-color,transform] duration-150 hover:bg-(--color-bg-hover) hover:text-(--color-ink) active:scale-90"
+                >
+                  <XIcon size={18} aria-hidden="true" />
+                </button>
+              </div>
+              <div className="px-5 pb-5">
+                <ResumeSectionContent section={section} writings={writings} />
+              </div>
             </ScrollArea>
           </motion.div>
         </div>

--- a/src/components/resume/CozyRoom/Room.tsx
+++ b/src/components/resume/CozyRoom/Room.tsx
@@ -2,7 +2,13 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import { XIcon } from 'lucide-react';
 import { motion } from 'motion/react';
-import { AmbientLight, DirectionalLight, Object3D } from 'three';
+import {
+  AmbientLight,
+  DirectionalLight,
+  Group,
+  Object3D,
+  Vector3,
+} from 'three';
 
 import type { WritingItem } from '@/blog/types';
 import { Heading } from '@/components/common/Heading';
@@ -12,7 +18,14 @@ import { CHESS_POSITION_FEN } from '../data';
 import { ScrollArea } from '../ScrollArea';
 
 import { aboutPanelAnchor } from './avatarState';
-import { HOTSPOTS, PANEL_PLACEMENTS, SectionId, ViewId } from './hotspots';
+import {
+  HOTSPOTS,
+  PANEL_GUTTER,
+  PANEL_MARGIN,
+  PANEL_PLACEMENTS,
+  SectionId,
+  ViewId,
+} from './hotspots';
 import { useLivePalette } from './livePalette';
 import { SceneHtml } from './SceneHtml';
 import {
@@ -57,25 +70,37 @@ type RoomProps = {
   // Render section content as a panel inside the scene (desktop)
   panel3d: boolean;
   writings: WritingItem[];
+  // Pixels the canvas overhangs its slot by, top and bottom. Panels stay
+  // out of the overhang — it runs over the page's own copy.
+  bleed: number;
   onHover: (id: SectionId | null) => void;
   onSelect: (id: SectionId) => void;
   onClose: () => void;
   onCycleTheme: () => void;
 };
 
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), Math.max(min, max));
+
+const projected = new Vector3();
+
 function ScenePanel({
   section,
   writings,
+  bleed,
   onClose,
 }: {
   section: SectionId;
   writings: WritingItem[];
+  bleed: number;
   onClose: () => void;
 }) {
   const placement = PANEL_PLACEMENTS[section];
   const camera = useThree((state) => state.camera);
   const headingId = `scene-panel-${section}`;
   const closeRef = useRef<HTMLButtonElement>(null);
+  const anchorRef = useRef<Group>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
 
   // Send focus into the panel when it opens, and hand it back to the
   // element that opened it once it closes
@@ -93,21 +118,49 @@ function ScenePanel({
     () =>
       section === 'about'
         ? aboutPanelAnchor(camera.position).toArray()
-        : placement.position,
+        : placement.anchor,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 
+  // drei drops the overlay at the anchor's projection; the card is then
+  // sat beside it in screen pixels, so the gap between object and card is
+  // the same whatever the camera and the viewport are doing. It stops
+  // following at the edges of the slot rather than sliding out of view.
+  useFrame((state) => {
+    const group = anchorRef.current;
+    const card = cardRef.current;
+    if (!group || !card) return;
+
+    projected.setFromMatrixPosition(group.matrixWorld).project(state.camera);
+    const x = (projected.x * 0.5 + 0.5) * state.size.width;
+    const y = (0.5 - projected.y * 0.5) * state.size.height;
+    const { offsetWidth: width, offsetHeight: height } = card;
+
+    const left = clamp(
+      placement.side === 'right' ? x + PANEL_GUTTER : x - PANEL_GUTTER - width,
+      PANEL_MARGIN,
+      state.size.width - width - PANEL_MARGIN,
+    );
+    const top = clamp(
+      y - height / 2,
+      bleed + PANEL_MARGIN,
+      state.size.height - bleed - height - PANEL_MARGIN,
+    );
+
+    // Single-element 3D tilt — browsers hit-test this correctly, unlike
+    // nested matrix3d chains
+    card.style.transform =
+      `translate3d(${Math.round(left - x)}px, ${Math.round(top - y)}px, 0)` +
+      ` perspective(1100px) rotateY(${placement.tilt}deg)`;
+  });
+
   return (
-    <group position={anchor}>
-      <SceneHtml center zIndexRange={[40, 0]}>
-        {/* Single-element 3D tilt — browsers hit-test this correctly,
-            unlike nested matrix3d chains */}
-        <div
-          style={{
-            transform: `perspective(1100px) rotateY(${placement.tilt}deg)`,
-          }}
-        >
+    <group ref={anchorRef} position={anchor}>
+      {/* Inert wrapper: the card is offset out of this box, so anything the
+          box still covers has to stay clickable */}
+      <SceneHtml style={{ pointerEvents: 'none' }} zIndexRange={[40, 0]}>
+        <div ref={cardRef} className="pointer-events-auto">
           <motion.div
             role="dialog"
             aria-modal="false"
@@ -206,6 +259,7 @@ export function Room({
   hovered,
   panel3d,
   writings,
+  bleed,
   onHover,
   onSelect,
   onClose,
@@ -334,6 +388,7 @@ export function Room({
           key={view}
           section={view}
           writings={writings}
+          bleed={bleed}
           onClose={onClose}
         />
       )}

--- a/src/components/resume/CozyRoom/SceneHtml.tsx
+++ b/src/components/resume/CozyRoom/SceneHtml.tsx
@@ -19,8 +19,19 @@ const HtmlPortalContext = createContext<RefObject<HTMLElement | null> | null>(
 
 export const HtmlPortalProvider = HtmlPortalContext.Provider;
 
-export function SceneHtml(props: HtmlProps) {
+export function SceneHtml({ style, ...props }: HtmlProps) {
   const portal = useContext(HtmlPortalContext);
 
-  return <Html {...props} portal={portal as RefObject<HTMLElement>} />;
+  return (
+    <Html
+      {...props}
+      // The layer is inert so the room stays clickable through it, and drei
+      // leaves this element to inherit that — which quietly made every
+      // overlay in the room unclickable and unscrollable. Overlays whose
+      // content sits away from their anchor opt back out and re-enable the
+      // content itself, so they don't leave an invisible blocker behind.
+      style={{ pointerEvents: 'auto', ...style }}
+      portal={portal as RefObject<HTMLElement>}
+    />
+  );
 }

--- a/src/components/resume/CozyRoom/avatarState.ts
+++ b/src/components/resume/CozyRoom/avatarState.ts
@@ -50,11 +50,14 @@ export function aboutCameraView(cameraPosition: Vector3, desktop: boolean) {
   return { position, target };
 }
 
-/** Anchor for the About panel: beside him, on the camera's right. */
+/**
+ * Anchor for the About panel: at his shoulder, on the camera's right. The
+ * card is then spaced off it in pixels, so this only has to clear his
+ * silhouette rather than leave room for the card itself.
+ */
 export function aboutPanelAnchor(cameraPosition: Vector3) {
-  const { dir, right } = approachBasis(cameraPosition);
+  const { right } = approachBasis(cameraPosition);
   return new Vector3(avatarPosition.x, 0, avatarPosition.z)
-    .addScaledVector(right, 1.62)
-    .addScaledVector(dir, 1.2)
-    .setY(1.5);
+    .addScaledVector(right, 0.75)
+    .setY(1.2);
 }

--- a/src/components/resume/CozyRoom/hotspots.ts
+++ b/src/components/resume/CozyRoom/hotspots.ts
@@ -35,21 +35,39 @@ export const CAMERA_VIEWS_MOBILE: Record<ViewId, CameraView> = {
 // Where the camera starts before the intro swoop
 export const INTRO_CAMERA_POSITION: [number, number, number] = [15, 11, 18];
 
-// Where the in-scene content panel anchors for each section (desktop).
-// The panel is a screen-space card anchored at `position`, tilted by
-// `tilt` degrees via a single-element CSS perspective transform. (A full
-// drei `Html transform` matrix chain paints correctly but Chromium
-// hit-tests it offset, which made links hover in the wrong place.)
+// Where the in-scene content panel hangs off each section's object
+// (desktop).
+//
+// `anchor` is a world point on the edge of the object the panel belongs to,
+// and the card is laid out beside that point's *projection*, on `side`, with
+// a fixed pixel gutter. The card never scales with the scene, so a world-space
+// offset of its own is only ever right at one framing: change the viewport's
+// aspect and the same offset reads as a card's width of empty room. Anchoring
+// to the object and spacing in pixels keeps the gap the size it looks.
+//
+// `tilt` degrees, via a single-element CSS perspective transform. (A full
+// drei `Html transform` matrix chain paints correctly but Chromium hit-tests
+// it offset, which made links hover in the wrong place.)
 export const PANEL_PLACEMENTS: Record<
   SectionId,
-  { position: [number, number, number]; tilt: number }
+  { anchor: [number, number, number]; side: 'left' | 'right'; tilt: number }
 > = {
-  projects: { position: [3.15, 1.6, -2.9], tilt: -14 },
-  career: { position: [1.2, 2.1, -3.9], tilt: 10 },
-  writing: { position: [-3.5, 1.65, -0.45], tilt: 12 },
-  about: { position: [2.75, 1.15, 2.7], tilt: -14 },
-  contact: { position: [-1.8, 1.75, -2.35], tilt: 10 },
+  // Outer edge of the right-hand monitor
+  projects: { anchor: [2.35, 1.62, -3.66], side: 'right', tilt: -14 },
+  // Inner edge of the corkboard's frame
+  career: { anchor: [1.94, 2.2, -4.1], side: 'left', tilt: 10 },
+  // Front-near corner of the bookshelf
+  writing: { anchor: [-3.68, 1.3, 0.62], side: 'right', tilt: 12 },
+  // Overridden at open time — he is wherever he wandered to
+  about: { anchor: [1.2, 1.15, 1.9], side: 'right', tilt: -14 },
+  // Left edge of the stack of envelopes
+  contact: { anchor: [-0.62, 1.24, -2.32], side: 'left', tilt: 10 },
 };
+
+// Pixels between the object's edge and the card, and the least the card
+// will keep from the edges of the room's slot before it stops following.
+export const PANEL_GUTTER = 20;
+export const PANEL_MARGIN = 16;
 
 export type Hotspot = {
   id: SectionId;

--- a/src/components/resume/CozyRoom/index.tsx
+++ b/src/components/resume/CozyRoom/index.tsx
@@ -179,6 +179,7 @@ export function CozyRoomScene({
             hovered={hovered}
             panel3d={desktop}
             writings={writings}
+            bleed={bleed}
             onHover={setHovered}
             onSelect={onSelect}
             onClose={onClose}

--- a/src/components/resume/CozyRoom/objects.tsx
+++ b/src/components/resume/CozyRoom/objects.tsx
@@ -747,9 +747,16 @@ export function DeskLamp({ onCycleTheme }: { onCycleTheme: () => void }) {
         onCycleTheme();
       }}
     >
+      {/* Inert: it only exists while the lamp is hovered, and catching the
+          pointer itself would call off its own hover */}
       {hovered && (
-        <SceneHtml center position={[-0.1, 0.85, 0]} zIndexRange={[40, 0]}>
-          <div className="pointer-events-none rounded-full border border-(--color-border-hi) bg-(--color-bg-panel) px-2.5 pt-[5px] pb-[3px] text-[11px] leading-none font-medium whitespace-nowrap text-(--color-ink-2) shadow-(--shadow-md)">
+        <SceneHtml
+          center
+          position={[-0.1, 0.85, 0]}
+          zIndexRange={[40, 0]}
+          style={{ pointerEvents: 'none' }}
+        >
+          <div className="rounded-full border border-(--color-border-hi) bg-(--color-bg-panel) px-2.5 pt-[5px] pb-[3px] text-[11px] leading-none font-medium whitespace-nowrap text-(--color-ink-2) shadow-(--shadow-md)">
             Flip the lights
           </div>
         </SceneHtml>

--- a/src/components/resume/ScrollArea.tsx
+++ b/src/components/resume/ScrollArea.tsx
@@ -36,7 +36,12 @@ export function ScrollArea({ className, children }: ScrollAreaProps) {
       <div
         ref={ref}
         onScroll={sync}
-        className={cn('min-h-0 flex-1 overflow-y-auto', className)}
+        // Contained, so reaching the last line hands the wheel back to the
+        // reader rather than carrying on down the page
+        className={cn(
+          'min-h-0 flex-1 overflow-y-auto overscroll-contain',
+          className,
+        )}
       >
         {children}
       </div>


### PR DESCRIPTION
The `/resume` panels floated a long way from the object that opened them, and nothing inside them could be clicked or scrolled. Two separate causes.

## The distance

The in-scene panel is a fixed-size screen-space card, but it was anchored at a world point of its own — so the gap between an object and its panel was whatever the projection happened to make it. It wasn't only too wide: at a 1440px window the projects card ran clean off the right edge of the room, and writing's sat a card's width clear of the bookshelf.

Each panel now anchors to a point on the **edge of the object it belongs to** — right-hand monitor, corkboard frame, the bookshelf's near corner, the envelope stack, his shoulder — and the card is laid out beside that point's *projection*, on a declared side, with a fixed 20px gutter. A `useFrame` in `ScenePanel` projects the anchor and writes the card's offset, clamping it to the room's slot so it stops following rather than sliding out of view or into the canvas's bleed overhang.

`aboutPanelAnchor` shrank to match: it used to push 1.62 to the camera's right *and* 1.2 toward the camera to leave room for the card, and now only has to clear his silhouette.

## The scrolling

Not a conflict with the zoom — the panels were completely inert. The layer the overlays mount into is `pointer-events: none` so the room stays clickable through it, and drei's `<Html>` leaves its element to inherit that. Nothing in the room's HTML worked: the panel wouldn't scroll, its links and close button didn't respond, the floating hotspot labels did nothing, nor did the avatar's own "About me" tag.

`SceneHtml` now switches events back on by default. The panel opts out again at its wrapper — its card sits away from its anchor, so an enabled wrapper would leave an invisible 360px blocker over the room — and re-enables the card itself. The lamp's "Flip the lights" tooltip opts out for the same reason, so it can't call off the hover that spawned it.

`ScrollArea` also gained `overscroll-contain`, so reaching the last line hands the wheel back to the reader instead of carrying on down the page.

## Verified

In Chromium against the dev server, at 1440 / 1024 / 820 wide:

- panels sit against their object with the gutter intact and stay fully on screen at every width
- the panel scrolls, its links navigate, its close button closes
- in-scene hotspot labels open their section (they were dead before)
- clicking the room still dismisses an open panel, and clicking another object still switches to it
- mobile bottom sheet unchanged

Typecheck and lint are clean, and the 7 `e2e/resume.spec.ts` specs pass.
